### PR TITLE
More specific exception

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -742,7 +742,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @param seconds Seconds to Skip
 	 */
 	//todo not finished needs more validations
-	public long seekSeconds(int seconds) throws Exception {
+	public long seekSeconds(int seconds) throws StreamPlayerException {
 		int durationInSeconds = this.getDurationInSeconds();
 
 		//Validate
@@ -774,7 +774,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param seconds Seconds to Skip
 	 */
-	public long seekTo(int seconds) throws Exception {
+	public long seekTo(int seconds) throws StreamPlayerException {
 		int durationInSeconds = this.getDurationInSeconds();
 
 		//Validate
@@ -800,11 +800,11 @@ public class StreamPlayer implements Callable<Void> {
 //		seek(bytes);
 //	}
 
-	private void validateSeconds(int seconds, int durationInSeconds) throws Exception {
+	private void validateSeconds(int seconds, int durationInSeconds) {
 		if (seconds < 0) {
-			throw new Exception("Trying to skip negative seconds ");
+			throw new UnsupportedOperationException("Trying to skip negative seconds ");
 		} else if (seconds >= durationInSeconds) {
-			throw new Exception("Trying to skip with seconds {" + seconds + "} > maximum {" + durationInSeconds + "}");
+			throw new UnsupportedOperationException("Trying to skip with seconds {" + seconds + "} > maximum {" + durationInSeconds + "}");
 		}
 	}
 

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerEventLauncher.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerEventLauncher.java
@@ -73,7 +73,7 @@ public class StreamPlayerEventLauncher implements Callable<String> {
     }
 
     @Override
-    public String call() throws Exception {
+    public String call() {
 	// Notify all the listeners that the state has been updated
 	if (listeners != null) {
 	    listeners.forEach(listener -> listener


### PR DESCRIPTION
Generally, it's not recommended to throw Exception. See for example https://rules.sonarsource.com/java/RSPEC-112

In class StreamPlayer, new Exception is changed into new UnsupportedOperationException

As a consequence, StreamPlayerEventLauncher.call() no longer throws a checked exception. UnsupportedOperationException is an unchecked exception.