### PR TITLE
Remove printing to System.out

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -583,7 +583,7 @@ public class StreamPlayer implements Callable<Void> {
 		try {
 			initLine();
 		} catch (final LineUnavailableException ex) {
-			throw new StreamPlayerException(StreamPlayerException.PlayerException.CAN_NOT_INIT_LINE, ex);
+			throw new StreamPlayerException(PlayerException.CAN_NOT_INIT_LINE, ex);
 		}
 
 		// Open the sourceDataLine
@@ -666,7 +666,7 @@ public class StreamPlayer implements Callable<Void> {
 								Thread.sleep(20);
 							else
 								break;
-							System.out.println("StreamPlayer Future is not yet done...");
+							logger.log(Level.INFO, "StreamPlayer Future is not yet done...");
 						}
 
 					} catch (final InterruptedException ex) {
@@ -708,7 +708,7 @@ public class StreamPlayer implements Callable<Void> {
 
 			// Check if the requested bytes are more than totalBytes of Audio
 			final long bytesLength = getTotalBytes();
-			System.out.println("Bytes: " + bytes + " BytesLength: " + bytesLength);
+			logger.log(Level.INFO, "Bytes: " + bytes + " BytesLength: " + bytesLength);
 			if ((bytesLength <= 0) || (bytes >= bytesLength)) {
 				generateEvent(Status.EOM, getEncodedStreamPosition(), null);
 				return totalSkipped;
@@ -734,7 +734,7 @@ public class StreamPlayer implements Callable<Void> {
 							logger.info("Skipped : " + totalSkipped + "/" + bytes);
 							if (totalSkipped == -1)
 								throw new StreamPlayerException(
-									StreamPlayerException.PlayerException.SKIP_NOT_SUPPORTED);
+									PlayerException.SKIP_NOT_SUPPORTED);
 
 							logger.info("Skeeping:" + totalSkipped);
 						}
@@ -1281,7 +1281,7 @@ public class StreamPlayer implements Callable<Void> {
 			balanceControl.setValue(fBalance);
 		else
 			try {
-				throw new StreamPlayerException(StreamPlayerException.PlayerException.BALANCE_CONTROL_NOT_SUPPORTED);
+				throw new StreamPlayerException(PlayerException.BALANCE_CONTROL_NOT_SUPPORTED);
 			} catch (final StreamPlayerException ex) {
 				logger.log(Level.WARNING, ex.getMessage(), ex);
 			}
@@ -1387,4 +1387,7 @@ public class StreamPlayer implements Callable<Void> {
 		return status == Status.SEEKING;
 	}
 
+	Logger getLogger() {
+		return logger;
+	}
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerEventLauncher.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerEventLauncher.java
@@ -24,6 +24,8 @@ package com.goxr3plus.streamplayer.stream;
 
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.goxr3plus.streamplayer.enums.Status;
 
@@ -34,6 +36,7 @@ import com.goxr3plus.streamplayer.enums.Status;
  */
 public class StreamPlayerEventLauncher implements Callable<String> {
 
+    private final Logger logger;
     /** The player state. */
     private Status playerState = Status.NOT_SPECIFIED;
 
@@ -61,15 +64,15 @@ public class StreamPlayerEventLauncher implements Callable<String> {
      * @param description
      *            the description
      * @param listeners
-     *            the listeners
      */
-    public StreamPlayerEventLauncher(Object source, Status playerStatus, int encodedStreamPosition, Object description,
-	    List<StreamPlayerListener> listeners) {
+    public StreamPlayerEventLauncher(StreamPlayer source, Status playerStatus, int encodedStreamPosition, Object description,
+                                     List<StreamPlayerListener> listeners) {
 	this.source = source;
 	this.playerState = playerStatus;
 	this.encodedStreamPosition = encodedStreamPosition;
 	this.description = description;
 	this.listeners = listeners;
+    this.logger = source.getLogger();
     }
 
     @Override
@@ -79,8 +82,7 @@ public class StreamPlayerEventLauncher implements Callable<String> {
 	    listeners.forEach(listener -> listener
 		    .statusUpdated(new StreamPlayerEvent(source, playerState, encodedStreamPosition, description)));
 	}
-
-	System.out.println("Stream player Status -> " + playerState);
+	logger.log(Level.INFO, "Stream player Status -> " + playerState);
 	return "OK";
     }
 }


### PR DESCRIPTION
 StreamPlayer is no longer printing to System.out. Instead messages are logged.
To be able to log instead of print in StreamPlayerEventLauncher, its constructor signature has been changed, so that the source is a StreamPlayer instead of an Object. The StreamPlayerEventLauncher uses the logger of the source.