### PR TITLE
Test with reset() behaves oddly

### DIFF
--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -403,5 +403,15 @@ public class StreamPlayerMethodsTest {
         fail("Test not done");
     }
 
+    @Test
+    void resetShouldStopPlayback() throws StreamPlayerException {
+        player.open((audioFile));
+        player.play();
+        System.out.println("play()");
+        player.reset();
+        System.out.println("reset()");
+        player.stop();
+    }
+
 
 }


### PR DESCRIPTION
reset() is a public method. If it's called when the player is playing, it seems to not return. I cannot really see what is executing when I run the test in the debugger.

The test print "play()", and goes on to play the song. It never prints "reset()"

Expected behavior: The player is stopped so quickly, that no music is heard. Maxium one frame of sound samples.
The word "reset() should be printed after "play()".

What can be learnt from this behavior?