### PR TITLE
Extract class from stream player

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/application/AnotherDemoApplication.java
+++ b/src/main/java/com/goxr3plus/streamplayer/application/AnotherDemoApplication.java
@@ -3,6 +3,7 @@ package com.goxr3plus.streamplayer.application;
 import com.goxr3plus.streamplayer.enums.Status;
 import com.goxr3plus.streamplayer.stream.StreamPlayer;
 import com.goxr3plus.streamplayer.stream.StreamPlayerEvent;
+import com.goxr3plus.streamplayer.stream.StreamPlayerInterface;
 import com.goxr3plus.streamplayer.stream.StreamPlayerListener;
 
 import java.io.File;
@@ -16,10 +17,10 @@ public class AnotherDemoApplication  {
 
 	private final String audioFileName = "Logic - Ballin [Bass Boosted].mp3";
 
-	private StreamPlayer streamPlayer;
+	private StreamPlayerInterface streamPlayer;
 	private StreamPlayerListener listener;
 
-	public AnotherDemoApplication(StreamPlayer streamPlayer) {
+	public AnotherDemoApplication(StreamPlayerInterface streamPlayer) {
 		this.streamPlayer = streamPlayer;
 		this.listener = new AnotherStreamPlayerListener(audioFileName, streamPlayer);
 

--- a/src/main/java/com/goxr3plus/streamplayer/application/AnotherMain.java
+++ b/src/main/java/com/goxr3plus/streamplayer/application/AnotherMain.java
@@ -1,12 +1,13 @@
 package com.goxr3plus.streamplayer.application;
 
 import com.goxr3plus.streamplayer.stream.StreamPlayer;
+import com.goxr3plus.streamplayer.stream.StreamPlayerInterface;
 import com.goxr3plus.streamplayer.stream.StreamPlayerListener;
 
 public class AnotherMain {
     public static void main(String[] args) {
 
-        final StreamPlayer streamPlayer = new StreamPlayer();
+        final StreamPlayerInterface streamPlayer = new StreamPlayer();
         final AnotherDemoApplication application = new AnotherDemoApplication(streamPlayer);
         application.start();
 

--- a/src/main/java/com/goxr3plus/streamplayer/application/AnotherStreamPlayerListener.java
+++ b/src/main/java/com/goxr3plus/streamplayer/application/AnotherStreamPlayerListener.java
@@ -3,6 +3,7 @@ package com.goxr3plus.streamplayer.application;
 import com.goxr3plus.streamplayer.enums.Status;
 import com.goxr3plus.streamplayer.stream.StreamPlayer;
 import com.goxr3plus.streamplayer.stream.StreamPlayerEvent;
+import com.goxr3plus.streamplayer.stream.StreamPlayerInterface;
 import com.goxr3plus.streamplayer.stream.StreamPlayerListener;
 
 import java.util.Map;
@@ -10,10 +11,10 @@ import java.util.Map;
 class AnotherStreamPlayerListener implements StreamPlayerListener {
 
     private final String audioFileName;
-    private StreamPlayer streamPlayer;
+    private StreamPlayerInterface streamPlayer;
 
 
-    public AnotherStreamPlayerListener(String audioFileName, StreamPlayer streamPlayer) {
+    public AnotherStreamPlayerListener(String audioFileName, StreamPlayerInterface streamPlayer) {
         this.audioFileName = audioFileName;
         this.streamPlayer = streamPlayer;
     }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -1,7 +1,5 @@
 package com.goxr3plus.streamplayer.stream;
 
-import com.goxr3plus.streamplayer.enums.Status;
-
 import javax.sound.sampled.BooleanControl;
 import javax.sound.sampled.Control;
 import javax.sound.sampled.FloatControl;
@@ -83,13 +81,21 @@ public class Outlet {
         }
     }
 
-    void stopAndFreeDataLine() {
+    void drainStopAndFreeDataLine() {
         // Free audio resources.
         if (sourceDataLine != null) {
             sourceDataLine.drain();
             sourceDataLine.stop();
             sourceDataLine.close();
-            this.sourceDataLine = null;
+            this.sourceDataLine = null;  // TODO: Is this necessary? Will it not be garbage collected?
+        }
+    }
+
+     void stopAndFreeDataLine() {
+        if (getSourceDataLine() != null) {
+            getSourceDataLine().flush();
+            getSourceDataLine().close();
+            this.sourceDataLine = null; // TODO: Is this necessary? Will it not be garbage collected?
         }
     }
 

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -66,4 +66,18 @@ public class Outlet {
     public boolean hasControl(final Control.Type control, final Control component) {
         return component != null && (getSourceDataLine() != null) && (getSourceDataLine().isControlSupported(control));
     }
+
+    /**
+     * Returns Gain value.
+     *
+     * @return The Gain Value
+     */
+    public float getGainValue() {
+
+        if (hasControl(FloatControl.Type.MASTER_GAIN, getGainControl())) {
+            return getGainControl().getValue();
+        } else {
+            return 0.0F;
+        }
+    }
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -1,6 +1,7 @@
 package com.goxr3plus.streamplayer.stream;
 
 import javax.sound.sampled.BooleanControl;
+import javax.sound.sampled.Control;
 import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.SourceDataLine;
 
@@ -51,5 +52,19 @@ public class Outlet {
 
     public void setSourceDataLine(SourceDataLine sourceDataLine) {
         this.sourceDataLine = sourceDataLine;
+    }
+
+
+    /**
+     * Check if the <b>Control</b> is Supported by m_line.
+     *
+     * @param control the control
+     * @param component the component
+     *
+     * @param streamPlayer
+     * @return true, if successful
+     */
+    public boolean hasControl(final Control.Type control, final Control component, StreamPlayer streamPlayer) {
+        return component != null && (getSourceDataLine() != null) && (getSourceDataLine().isControlSupported(control));
     }
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -10,49 +10,46 @@ public class Outlet {
     private FloatControl gainControl;
     private BooleanControl muteControl;
     private FloatControl panControl;
-
-    /** The source data line. */
     private SourceDataLine sourceDataLine;
 
-    public SourceDataLine getSourceDataLine() {
-        return sourceDataLine;
-    }
-
-    public void setSourceDataLine(SourceDataLine sourceDataLine) {
-        this.sourceDataLine = sourceDataLine;
-    }
-
-
-    public BooleanControl getMuteControl() {
-        return muteControl;
-    }
-
-    public void setMuteControl(BooleanControl muteControl) {
-        this.muteControl = muteControl;
-    }
-
-
-    public FloatControl getPanControl() {
-        return panControl;
-    }
-
-    public void setPanControl(FloatControl panControl) {
-        this.panControl = panControl;
-    }
 
     public FloatControl getBalanceControl() {
         return balanceControl;
-    }
-
-    public void setBalanceControl(FloatControl balanceControl) {
-        this.balanceControl = balanceControl;
     }
 
     public FloatControl getGainControl() {
         return gainControl;
     }
 
+    public BooleanControl getMuteControl() {
+        return muteControl;
+    }
+
+    public FloatControl getPanControl() {
+        return panControl;
+    }
+
+    public SourceDataLine getSourceDataLine() {
+        return sourceDataLine;
+    }
+
+    public void setBalanceControl(FloatControl balanceControl) {
+        this.balanceControl = balanceControl;
+    }
+
     public void setGainControl(FloatControl gainControl) {
         this.gainControl = gainControl;
+    }
+
+    public void setMuteControl(BooleanControl muteControl) {
+        this.muteControl = muteControl;
+    }
+
+    public void setPanControl(FloatControl panControl) {
+        this.panControl = panControl;
+    }
+
+    public void setSourceDataLine(SourceDataLine sourceDataLine) {
+        this.sourceDataLine = sourceDataLine;
     }
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -1,17 +1,20 @@
 package com.goxr3plus.streamplayer.stream;
 
-import javax.sound.sampled.BooleanControl;
-import javax.sound.sampled.Control;
-import javax.sound.sampled.FloatControl;
-import javax.sound.sampled.SourceDataLine;
+import javax.sound.sampled.*;
+import java.util.logging.Logger;
 
 public class Outlet {
 
+    private final Logger logger;
     private FloatControl balanceControl;
     private FloatControl gainControl;
     private BooleanControl muteControl;
     private FloatControl panControl;
     private SourceDataLine sourceDataLine;
+
+    public Outlet(Logger logger) {
+        this.logger = logger;
+    }
 
 
     public FloatControl getBalanceControl() {
@@ -112,6 +115,41 @@ public class Outlet {
     }
     void start() {
         getSourceDataLine().start();
+    }
+
+    void open(AudioFormat audioFormat, int currentLineBufferSize) throws LineUnavailableException {
+        logger.info("Entered OpenLine()!:\n");
+
+        if (getSourceDataLine() != null) {
+            getSourceDataLine().open(audioFormat, currentLineBufferSize);
+
+            // opened?
+            if (getSourceDataLine().isOpen()) {
+
+                // Master_Gain Control?
+                if (getSourceDataLine().isControlSupported(FloatControl.Type.MASTER_GAIN))
+                    setGainControl((FloatControl) getSourceDataLine().getControl(FloatControl.Type.MASTER_GAIN));
+                else setGainControl(null);
+
+                // PanControl?
+                if (getSourceDataLine().isControlSupported(FloatControl.Type.PAN))
+                    setPanControl((FloatControl) getSourceDataLine().getControl(FloatControl.Type.PAN));
+                else setPanControl(null);
+
+                // Mute?
+                BooleanControl muteControl1 = getSourceDataLine().isControlSupported(BooleanControl.Type.MUTE)
+                        ? (BooleanControl) getSourceDataLine().getControl(BooleanControl.Type.MUTE)
+                        : null;
+                setMuteControl(muteControl1);
+
+                // Speakers Balance?
+                FloatControl balanceControl = getSourceDataLine().isControlSupported(FloatControl.Type.BALANCE)
+                        ? (FloatControl) getSourceDataLine().getControl(FloatControl.Type.BALANCE)
+                        : null;
+                setBalanceControl(balanceControl);
+            }
+        }
+        logger.info("Exited OpenLine()!:\n");
     }
 
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -80,4 +80,14 @@ public class Outlet {
             return 0.0F;
         }
     }
+
+    void stopAndFreeDataLine() {
+        // Free audio resources.
+        if (sourceDataLine != null) {
+            sourceDataLine.drain();
+            sourceDataLine.stop();
+            sourceDataLine.close();
+            this.sourceDataLine = null;
+        }
+    }
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -107,4 +107,11 @@ public class Outlet {
         }
     }
 
+    boolean isStartable() {
+        return getSourceDataLine() != null && !getSourceDataLine().isRunning();
+    }
+    void start() {
+        getSourceDataLine().start();
+    }
+
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -6,6 +6,16 @@ public class Outlet {
 
     private FloatControl balanceControl;
     private FloatControl gainControl;
+    private FloatControl panControl;
+
+
+    public FloatControl getPanControl() {
+        return panControl;
+    }
+
+    public void setPanControl(FloatControl panControl) {
+        this.panControl = panControl;
+    }
 
     public FloatControl getBalanceControl() {
         return balanceControl;

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -1,5 +1,7 @@
 package com.goxr3plus.streamplayer.stream;
 
+import com.goxr3plus.streamplayer.enums.Status;
+
 import javax.sound.sampled.BooleanControl;
 import javax.sound.sampled.Control;
 import javax.sound.sampled.FloatControl;
@@ -90,4 +92,13 @@ public class Outlet {
             this.sourceDataLine = null;
         }
     }
+
+    void flushAndStop() {
+        // Flush and stop the source data line
+        if (getSourceDataLine() != null && getSourceDataLine().isRunning()) {
+            getSourceDataLine().flush();
+            getSourceDataLine().stop();
+        }
+    }
+
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -4,6 +4,17 @@ import javax.sound.sampled.FloatControl;
 
 public class Outlet {
 
+    private FloatControl balanceControl;
+    private FloatControl gainControl;
+
+    public FloatControl getBalanceControl() {
+        return balanceControl;
+    }
+
+    public void setBalanceControl(FloatControl balanceControl) {
+        this.balanceControl = balanceControl;
+    }
+
     public FloatControl getGainControl() {
         return gainControl;
     }
@@ -11,6 +22,4 @@ public class Outlet {
     public void setGainControl(FloatControl gainControl) {
         this.gainControl = gainControl;
     }
-
-    private FloatControl gainControl;
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -1,0 +1,16 @@
+package com.goxr3plus.streamplayer.stream;
+
+import javax.sound.sampled.FloatControl;
+
+public class Outlet {
+
+    public FloatControl getGainControl() {
+        return gainControl;
+    }
+
+    public void setGainControl(FloatControl gainControl) {
+        this.gainControl = gainControl;
+    }
+
+    private FloatControl gainControl;
+}

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -61,10 +61,9 @@ public class Outlet {
      * @param control the control
      * @param component the component
      *
-     * @param streamPlayer
      * @return true, if successful
      */
-    public boolean hasControl(final Control.Type control, final Control component, StreamPlayer streamPlayer) {
+    public boolean hasControl(final Control.Type control, final Control component) {
         return component != null && (getSourceDataLine() != null) && (getSourceDataLine().isControlSupported(control));
     }
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -67,7 +67,7 @@ public class Outlet {
      * @return true, if successful
      */
     public boolean hasControl(final Control.Type control, final Control component) {
-        return component != null && (getSourceDataLine() != null) && (getSourceDataLine().isControlSupported(control));
+        return component != null && (sourceDataLine != null) && (sourceDataLine.isControlSupported(control));
     }
 
     /**
@@ -95,56 +95,56 @@ public class Outlet {
     }
 
      void stopAndFreeDataLine() {
-        if (getSourceDataLine() != null) {
-            getSourceDataLine().flush();
-            getSourceDataLine().close();
+        if (sourceDataLine != null) {
+            sourceDataLine.flush();
+            sourceDataLine.close();
             this.sourceDataLine = null; // TODO: Is this necessary? Will it not be garbage collected?
         }
     }
 
     void flushAndStop() {
         // Flush and stop the source data line
-        if (getSourceDataLine() != null && getSourceDataLine().isRunning()) {
-            getSourceDataLine().flush();
-            getSourceDataLine().stop();
+        if (sourceDataLine != null && sourceDataLine.isRunning()) {
+            sourceDataLine.flush();
+            sourceDataLine.stop();
         }
     }
 
     boolean isStartable() {
-        return getSourceDataLine() != null && !getSourceDataLine().isRunning();
+        return sourceDataLine != null && !sourceDataLine.isRunning();
     }
     void start() {
-        getSourceDataLine().start();
+        sourceDataLine.start();
     }
 
     void open(AudioFormat audioFormat, int currentLineBufferSize) throws LineUnavailableException {
         logger.info("Entered OpenLine()!:\n");
 
-        if (getSourceDataLine() != null) {
-            getSourceDataLine().open(audioFormat, currentLineBufferSize);
+        if (sourceDataLine != null) {
+            sourceDataLine.open(audioFormat, currentLineBufferSize);
 
             // opened?
-            if (getSourceDataLine().isOpen()) {
+            if (sourceDataLine.isOpen()) {
 
                 // Master_Gain Control?
-                if (getSourceDataLine().isControlSupported(FloatControl.Type.MASTER_GAIN))
-                    setGainControl((FloatControl) getSourceDataLine().getControl(FloatControl.Type.MASTER_GAIN));
+                if (sourceDataLine.isControlSupported(FloatControl.Type.MASTER_GAIN))
+                    setGainControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.MASTER_GAIN));
                 else setGainControl(null);
 
                 // PanControl?
-                if (getSourceDataLine().isControlSupported(FloatControl.Type.PAN))
-                    setPanControl((FloatControl) getSourceDataLine().getControl(FloatControl.Type.PAN));
+                if (sourceDataLine.isControlSupported(FloatControl.Type.PAN))
+                    setPanControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.PAN));
                 else setPanControl(null);
 
                 // Mute?
-                BooleanControl muteControl1 = getSourceDataLine().isControlSupported(BooleanControl.Type.MUTE)
-                        ? (BooleanControl) getSourceDataLine().getControl(BooleanControl.Type.MUTE)
+                BooleanControl muteControl1 = sourceDataLine.isControlSupported(BooleanControl.Type.MUTE)
+                        ? (BooleanControl) sourceDataLine.getControl(BooleanControl.Type.MUTE)
                         : null;
                 setMuteControl(muteControl1);
 
                 // Speakers Balance?
-                FloatControl balanceControl = getSourceDataLine().isControlSupported(FloatControl.Type.BALANCE)
-                        ? (FloatControl) getSourceDataLine().getControl(FloatControl.Type.BALANCE)
+                FloatControl balanceControl = sourceDataLine.isControlSupported(FloatControl.Type.BALANCE)
+                        ? (FloatControl) sourceDataLine.getControl(FloatControl.Type.BALANCE)
                         : null;
                 setBalanceControl(balanceControl);
             }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -1,12 +1,23 @@
 package com.goxr3plus.streamplayer.stream;
 
+import javax.sound.sampled.BooleanControl;
 import javax.sound.sampled.FloatControl;
 
 public class Outlet {
 
     private FloatControl balanceControl;
     private FloatControl gainControl;
+    private BooleanControl muteControl;
     private FloatControl panControl;
+
+
+    public BooleanControl getMuteControl() {
+        return muteControl;
+    }
+
+    public void setMuteControl(BooleanControl muteControl) {
+        this.muteControl = muteControl;
+    }
 
 
     public FloatControl getPanControl() {

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -3,6 +3,14 @@ package com.goxr3plus.streamplayer.stream;
 import javax.sound.sampled.*;
 import java.util.logging.Logger;
 
+/**
+ * Owner of the SourceDataLine which is the output line of the player.
+ * Also owns controls for the SourceDataLine.
+ * Future goal is to move all handling of the SourceDataLine to here,
+ * so that the StreamPlayer doesn't have to call {@link #getSourceDataLine()}.
+ * Another goal is to remove some of the setter and getter methods of this class,
+ * by moving all code that needs them to this class.
+ */
 public class Outlet {
 
     private final Logger logger;
@@ -12,47 +20,82 @@ public class Outlet {
     private FloatControl panControl;
     private SourceDataLine sourceDataLine;
 
+    /**
+     * @param logger used to log messages
+     */
     public Outlet(Logger logger) {
         this.logger = logger;
     }
 
 
+    /**
+     * @return the balance control of the {@link #sourceDataLine}
+     */
     public FloatControl getBalanceControl() {
         return balanceControl;
     }
 
+    /**
+     * @return the gain control of the {@link #sourceDataLine}
+     */
     public FloatControl getGainControl() {
         return gainControl;
     }
 
+    /**
+     * @return the mute control of the {@link #sourceDataLine}
+     */
     public BooleanControl getMuteControl() {
         return muteControl;
     }
 
+    /**
+     * @return the pan control of the {@link #sourceDataLine}
+     */
     public FloatControl getPanControl() {
         return panControl;
     }
 
+    /**
+     * @return the {@link #sourceDataLine}, which is the output audio signal of the player
+     */
     public SourceDataLine getSourceDataLine() {
         return sourceDataLine;
     }
 
+
+    /**
+     * @param balanceControl to be set on the {@link #sourceDataLine}
+     */
     public void setBalanceControl(FloatControl balanceControl) {
         this.balanceControl = balanceControl;
     }
 
+    /**
+     * @param gainControl to be set on the {@link #sourceDataLine}
+     */
     public void setGainControl(FloatControl gainControl) {
         this.gainControl = gainControl;
     }
 
+    /**
+     * @param muteControl to be set on the {@link #sourceDataLine}
+     */
     public void setMuteControl(BooleanControl muteControl) {
         this.muteControl = muteControl;
     }
 
+    /**
+     * @param panControl to be set on the {@link #sourceDataLine}
+     */
     public void setPanControl(FloatControl panControl) {
         this.panControl = panControl;
     }
 
+    /**
+     * @param sourceDataLine representing the audio output of the player.
+     *                       Usually taken from {@link AudioSystem#getLine(Line.Info)}.
+     */
     public void setSourceDataLine(SourceDataLine sourceDataLine) {
         this.sourceDataLine = sourceDataLine;
     }
@@ -84,6 +127,10 @@ public class Outlet {
         }
     }
 
+    /**
+     * Stop the {@link #sourceDataLine} in a nice way.
+     * Also nullify it. (Is that necessary?)
+     */
     void drainStopAndFreeDataLine() {
         // Free audio resources.
         if (sourceDataLine != null) {
@@ -94,7 +141,11 @@ public class Outlet {
         }
     }
 
-     void stopAndFreeDataLine() {
+    /**
+     * Flush and close the {@link #sourceDataLine} in a nice way.
+     * Also nullify it. (Is that necessary?)
+     */
+     void flushAndFreeDataLine() {
         if (sourceDataLine != null) {
             sourceDataLine.flush();
             sourceDataLine.close();
@@ -102,26 +153,44 @@ public class Outlet {
         }
     }
 
+    /**
+     * Flush and stop the {@link #sourceDataLine}, if it's running.
+     */
     void flushAndStop() {
         // Flush and stop the source data line
-        if (sourceDataLine != null && sourceDataLine.isRunning()) {
+        if (sourceDataLine != null && sourceDataLine.isRunning()) { // TODO: Risk for NullPointerException?
             sourceDataLine.flush();
             sourceDataLine.stop();
         }
     }
 
+    /**
+     * @return true if the {@link #sourceDataLine} is startable.
+     */
     boolean isStartable() {
         return sourceDataLine != null && !sourceDataLine.isRunning();
     }
+
+
+    /**
+     * Start the {@link #sourceDataLine}
+     */
     void start() {
         sourceDataLine.start();
     }
 
-    void open(AudioFormat audioFormat, int currentLineBufferSize) throws LineUnavailableException {
+    /**
+     * Open the {@link #sourceDataLine}.
+     * Also create controls for it.
+     * @param format The wanted audio format.
+     * @param bufferSize the desired buffer size for the {@link #sourceDataLine}
+     * @throws LineUnavailableException
+     */
+    void open(AudioFormat format, int bufferSize) throws LineUnavailableException {
         logger.info("Entered OpenLine()!:\n");
 
         if (sourceDataLine != null) {
-            sourceDataLine.open(audioFormat, currentLineBufferSize);
+            sourceDataLine.open(format, bufferSize);
 
             // opened?
             if (sourceDataLine.isOpen()) {

--- a/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/Outlet.java
@@ -2,6 +2,7 @@ package com.goxr3plus.streamplayer.stream;
 
 import javax.sound.sampled.BooleanControl;
 import javax.sound.sampled.FloatControl;
+import javax.sound.sampled.SourceDataLine;
 
 public class Outlet {
 
@@ -9,6 +10,17 @@ public class Outlet {
     private FloatControl gainControl;
     private BooleanControl muteControl;
     private FloatControl panControl;
+
+    /** The source data line. */
+    private SourceDataLine sourceDataLine;
+
+    public SourceDataLine getSourceDataLine() {
+        return sourceDataLine;
+    }
+
+    public void setSourceDataLine(SourceDataLine sourceDataLine) {
+        this.sourceDataLine = sourceDataLine;
+    }
 
 
     public BooleanControl getMuteControl() {

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -82,7 +82,7 @@ public class StreamPlayer implements Callable<Void> {
 
 	/** The audio file format. */
 	private AudioFileFormat audioFileFormat;
-	
+
 	// -------------------LOCKS---------------------
 
 	/**
@@ -1385,4 +1385,7 @@ public class StreamPlayer implements Callable<Void> {
 		return logger;
 	}
 
+	public SourceDataLine getSourceDataLine() {
+		return outlet.getSourceDataLine();
+	}
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -1085,12 +1085,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getGainValue() {
-
-		if (outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
-			return outlet.getGainControl().getValue();
-        } else {
-            return 0.0F;
-        }
+		return outlet.getGainValue();
     }
 
 	/**

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -572,8 +572,8 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		}
 
 		// Open the sourceDataLine
-		if (outlet.getSourceDataLine() != null && !outlet.getSourceDataLine().isRunning()) {
-			outlet.getSourceDataLine().start();
+		if (outlet.isStartable()) {
+			outlet.start();
 
 			// Proceed only if we have not problems
 			logger.info("Submitting new StreamPlayer Thread");

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -171,7 +171,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		this.streamPlayerExecutorService = streamPlayerExecutorService;
 		this.eventsExecutorService = eventsExecutorService;
 		listeners = new ArrayList<>();
-		outlet = new Outlet();
+		outlet = new Outlet(logger);
 		reset();
 	}
 
@@ -505,41 +505,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 * @param currentLineBufferSize
 	 */
 	private void openLine(AudioFormat audioFormat, int currentLineBufferSize) throws LineUnavailableException {
-
-		logger.info("Entered OpenLine()!:\n");
-
-		if (outlet.getSourceDataLine() != null) {
-			outlet.getSourceDataLine().open(audioFormat, currentLineBufferSize);
-
-			// opened?
-			if (outlet.getSourceDataLine().isOpen()) {
-
-				// Master_Gain Control?
-				if (outlet.getSourceDataLine().isControlSupported(FloatControl.Type.MASTER_GAIN))
-					outlet.setGainControl((FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.MASTER_GAIN));
-				else outlet.setGainControl(null);
-
-				// PanControl?
-				if (outlet.getSourceDataLine().isControlSupported(FloatControl.Type.PAN))
-					outlet.setPanControl((FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.PAN));
-				else outlet.setPanControl(null);
-
-				// Mute?
-				BooleanControl muteControl1 = outlet.getSourceDataLine().isControlSupported(BooleanControl.Type.MUTE)
-					? (BooleanControl) outlet.getSourceDataLine().getControl(BooleanControl.Type.MUTE)
-					: null;
-				outlet.setMuteControl(muteControl1);
-
-				// Speakers Balance?
-				FloatControl balanceControl = outlet.getSourceDataLine().isControlSupported(FloatControl.Type.BALANCE)
-					? (FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.BALANCE)
-					: null;
-				outlet.setBalanceControl(balanceControl);
-			}
-
-		}
-
-		logger.info("Exited OpenLine()!:\n");
+		outlet.open(audioFormat, currentLineBufferSize);
 	}
 
 	/**

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -186,12 +186,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 			closeStream();
 		}
 
-		// Source Data Line
-		if (outlet.getSourceDataLine() != null) {
-			outlet.getSourceDataLine().flush();
-			outlet.getSourceDataLine().close();
-			outlet.setSourceDataLine(null);
-		}
+		outlet.stopAndFreeDataLine();
 
 		// AudioFile
 		audioInputStream = null;
@@ -937,7 +932,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 				}
 			}
 			// Free audio resources.
-			outlet.stopAndFreeDataLine();
+			outlet.drainStopAndFreeDataLine();
 
 			// Close stream.
 			closeStream();

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -88,9 +88,6 @@ public class StreamPlayer implements Callable<Void> {
 
 	// -------------------CONTROLS---------------------
 
-	/** The pan control. */
-	private FloatControl panControl;
-
 	/** The mute control. */
 	private BooleanControl muteControl;
 
@@ -213,7 +210,7 @@ public class StreamPlayer implements Callable<Void> {
 
 		// Controls
 		outlet.setGainControl(null);
-		panControl = null;
+		outlet.setPanControl(null);
 		outlet.setBalanceControl(null);
 		// sampleRateControl = null
 
@@ -534,8 +531,8 @@ public class StreamPlayer implements Callable<Void> {
 
 				// PanControl?
 				if (sourceDataLine.isControlSupported(FloatControl.Type.PAN))
-					panControl = (FloatControl) sourceDataLine.getControl(FloatControl.Type.PAN);
-				else panControl = null;
+					outlet.setPanControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.PAN));
+				else outlet.setPanControl(null);
 
 				// SampleRate?
 				// if (sourceDataLine.isControlSupported(FloatControl.Type.SAMPLE_RATE))
@@ -1125,7 +1122,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @return The Precision Value
 	 */
 	public float getPrecision() {
-		return !hasControl(FloatControl.Type.PAN, panControl) ? 0.0F : panControl.getPrecision();
+		return !hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getPrecision();
 
 	}
 
@@ -1135,7 +1132,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @return The Pan Value
 	 */
 	public float getPan() {
-		return !hasControl(FloatControl.Type.PAN, panControl) ? 0.0F : panControl.getValue();
+		return !hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getValue();
 
 	}
 
@@ -1240,10 +1237,10 @@ public class StreamPlayer implements Callable<Void> {
 	 */
 	public void setPan(final double fPan) {
 
-		if (!hasControl(FloatControl.Type.PAN, panControl) || fPan < -1.0 || fPan > 1.0)
+		if (!hasControl(FloatControl.Type.PAN, outlet.getPanControl()) || fPan < -1.0 || fPan > 1.0)
 			return;
 		logger.info(() -> "Pan : " + fPan);
-		panControl.setValue((float) fPan);
+		outlet.getPanControl().setValue((float) fPan);
 		generateEvent(Status.PAN, getEncodedStreamPosition(), null);
 
 	}

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -185,7 +185,13 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		synchronized (audioLock) {
 			closeStream();
 		}
-		resetOutlet();
+
+		// Source Data Line
+		if (outlet.getSourceDataLine() != null) {
+			outlet.getSourceDataLine().flush();
+			outlet.getSourceDataLine().close();
+			outlet.setSourceDataLine(null);
+		}
 
 		// AudioFile
 		audioInputStream = null;
@@ -194,27 +200,15 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		encodedAudioLength = -1;
 
 		// Controls
-		resetControls();
+		outlet.setGainControl(null);
+		outlet.setPanControl(null);
+		outlet.setBalanceControl(null);
+		// sampleRateControl = null
 
 		// Notify the Status
 		status = Status.NOT_SPECIFIED;
 		generateEvent(Status.NOT_SPECIFIED, AudioSystem.NOT_SPECIFIED, null);
 
-	}
-
-	private void resetControls() {
-		outlet.setGainControl(null);
-		outlet.setPanControl(null);
-		outlet.setBalanceControl(null);
-	}
-
-	private void resetOutlet() {
-		// Source Data Line
-		if (outlet.getSourceDataLine() != null) {
-			outlet.getSourceDataLine().flush();
-			outlet.getSourceDataLine().close();
-			outlet.setSourceDataLine(null);
-		}
 	}
 
 	/**

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -502,26 +502,27 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 
 		logger.info("Entered OpenLine()!:\n");
 
-		if (outlet.getSourceDataLine() != null) {
+		final SourceDataLine sourceDataLine = outlet.getSourceDataLine();
+		if (sourceDataLine != null) {
 			final AudioFormat audioFormat = audioInputStream.getFormat();
-			currentLineBufferSize = lineBufferSize >= 0 ? lineBufferSize : outlet.getSourceDataLine().getBufferSize();
-			outlet.getSourceDataLine().open(audioFormat, currentLineBufferSize);
+			currentLineBufferSize = lineBufferSize >= 0 ? lineBufferSize : sourceDataLine.getBufferSize();
+			sourceDataLine.open(audioFormat, currentLineBufferSize);
 
 			// opened?
-			if (outlet.getSourceDataLine().isOpen()) {
+			if (sourceDataLine.isOpen()) {
 				// logger.info(() -> "Open Line Buffer Size=" + bufferSize + "\n");
 
 				/*-- Display supported controls --*/
 				// Control[] c = m_line.getControls()
 
 				// Master_Gain Control?
-				if (outlet.getSourceDataLine().isControlSupported(FloatControl.Type.MASTER_GAIN))
-					outlet.setGainControl((FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.MASTER_GAIN));
+				if (sourceDataLine.isControlSupported(FloatControl.Type.MASTER_GAIN))
+					outlet.setGainControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.MASTER_GAIN));
 				else outlet.setGainControl(null);
 
 				// PanControl?
-				if (outlet.getSourceDataLine().isControlSupported(FloatControl.Type.PAN))
-					outlet.setPanControl((FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.PAN));
+				if (sourceDataLine.isControlSupported(FloatControl.Type.PAN))
+					outlet.setPanControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.PAN));
 				else outlet.setPanControl(null);
 
 				// SampleRate?
@@ -532,14 +533,14 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 				// sampleRateControl = null
 
 				// Mute?
-				BooleanControl muteControl1 = outlet.getSourceDataLine().isControlSupported(BooleanControl.Type.MUTE)
-					? (BooleanControl) outlet.getSourceDataLine().getControl(BooleanControl.Type.MUTE)
+				BooleanControl muteControl1 = sourceDataLine.isControlSupported(BooleanControl.Type.MUTE)
+					? (BooleanControl) sourceDataLine.getControl(BooleanControl.Type.MUTE)
 					: null;
 				outlet.setMuteControl(muteControl1);
 
 				// Speakers Balance?
-				FloatControl balanceControl = outlet.getSourceDataLine().isControlSupported(FloatControl.Type.BALANCE)
-					? (FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.BALANCE)
+				FloatControl balanceControl = sourceDataLine.isControlSupported(FloatControl.Type.BALANCE)
+					? (FloatControl) sourceDataLine.getControl(FloatControl.Type.BALANCE)
 					: null;
 				outlet.setBalanceControl(balanceControl);
 			}
@@ -630,7 +631,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	public boolean resume() {
 		if (outlet.getSourceDataLine() == null || status != Status.PAUSED)
 			return false;
-		outlet.getSourceDataLine().start();
+		outlet.start();
 		status = Status.PLAYING;
 		generateEvent(Status.RESUMED, getEncodedStreamPosition(), null);
 		logger.info("resumePlayback() completed");
@@ -857,15 +858,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 			// Main play/pause loop.
 			while ((nBytesRead != -1) && status != Status.STOPPED && status != Status.NOT_SPECIFIED
 				&& status != Status.SEEKING) {
-				// if (status == Status.SEEKING) {
-				// try {
-				// System.out.println("Audio Seeking ...");
-				// Thread.sleep(50);
-				// } catch (InterruptedException e) {
-				// e.printStackTrace();
-				// }
-				// continue;
-				// }
 
 				try {
 					// Playing?

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -88,17 +88,8 @@ public class StreamPlayer implements Callable<Void> {
 
 	// -------------------CONTROLS---------------------
 
-	/** The gain control. */
-	//private FloatControl gainControl;
-
 	/** The pan control. */
 	private FloatControl panControl;
-
-	/** The balance control. */
-//	private FloatControl balanceControl;
-
-	/** The sample rate control. */
-	// private FloatControl sampleRateControl
 
 	/** The mute control. */
 	private BooleanControl muteControl;

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -1086,7 +1086,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	@Override
 	public float getGainValue() {
 
-		if (outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this)) {
+		if (outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
 			return outlet.getGainControl().getValue();
         } else {
             return 0.0F;
@@ -1100,7 +1100,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getMaximumGain() {
-		return !outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this) ? 0.0F : outlet.getGainControl().getMaximum();
+		return !outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMaximum();
 
 	}
 
@@ -1112,7 +1112,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	@Override
 	public float getMinimumGain() {
 
-		return !outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this) ? 0.0F : outlet.getGainControl().getMinimum();
+		return !outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMinimum();
 
 	}
 
@@ -1123,7 +1123,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getPrecision() {
-		return !outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl(), this) ? 0.0F : outlet.getPanControl().getPrecision();
+		return !outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getPrecision();
 
 	}
 
@@ -1134,7 +1134,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getPan() {
-		return !outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl(), this) ? 0.0F : outlet.getPanControl().getValue();
+		return !outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getValue();
 
 	}
 
@@ -1145,7 +1145,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public boolean getMute() {
-		return outlet.hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl(), this) && outlet.getMuteControl().getValue();
+		return outlet.hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue();
 	}
 
 	/**
@@ -1155,7 +1155,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getBalance() {
-		return !outlet.hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl(), this) ? 0f : outlet.getBalanceControl().getValue();
+		return !outlet.hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) ? 0f : outlet.getBalanceControl().getValue();
 	}
 
 	/****
@@ -1242,7 +1242,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	@Override
 	public void setPan(final double fPan) {
 
-		if (!outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl(), this) || fPan < -1.0 || fPan > 1.0)
+		if (!outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl()) || fPan < -1.0 || fPan > 1.0)
 			return;
 		logger.info(() -> "Pan : " + fPan);
 		outlet.getPanControl().setValue((float) fPan);
@@ -1258,7 +1258,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void setGain(final double fGain) {
-		if (isPlaying() || isPaused() && outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this)) {
+		if (isPlaying() || isPaused() && outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
             final double logScaleGain = 20 * Math.log10(fGain);
 			outlet.getGainControl().setValue((float) logScaleGain);
         }
@@ -1266,7 +1266,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 
 	@Override
 	public void setLogScaleGain(final double logScaleGain) {
-		if (isPlaying() || isPaused() && outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this)) {
+		if (isPlaying() || isPaused() && outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
 			outlet.getGainControl().setValue((float) logScaleGain);
 		}
 	}
@@ -1278,7 +1278,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void setMute(final boolean mute) {
-		if (outlet.hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl(), this) && outlet.getMuteControl().getValue() != mute)
+		if (outlet.hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue() != mute)
 			outlet.getMuteControl().setValue(mute);
 	}
 
@@ -1291,7 +1291,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void setBalance(final float fBalance) {
-		if (outlet.hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl(), this) && fBalance >= -1.0 && fBalance <= 1.0)
+		if (outlet.hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) && fBalance >= -1.0 && fBalance <= 1.0)
 			outlet.getBalanceControl().setValue(fBalance);
 		else
 			try {

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -60,14 +60,14 @@ import javazoom.spi.PropertiesContainer;
  * @author GOXR3PLUS (www.goxr3plus.co.nf)
  * @author JavaZOOM (www.javazoom.net)
  */
-public class StreamPlayer implements Callable<Void> {
+public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 
 	/**
 	 * Class logger
 	 */
 	private Logger logger;
 
-	// -------------------AUDIO---------------------
+	// -------------------AUDIO----------------,-----
 
 	private volatile Status status = Status.NOT_SPECIFIED;
 
@@ -180,6 +180,7 @@ public class StreamPlayer implements Callable<Void> {
 	/**
 	 * Freeing the resources.
 	 */
+	@Override
 	public void reset() {
 
 		// Close the stream
@@ -237,6 +238,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param streamPlayerListener the listener
 	 */
+	@Override
 	public void addStreamPlayerListener(final StreamPlayerListener streamPlayerListener) {
 		listeners.add(streamPlayerListener);
 	}
@@ -246,6 +248,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param streamPlayerListener the listener
 	 */
+	@Override
 	public void removeStreamPlayerListener(final StreamPlayerListener streamPlayerListener) {
 		if (listeners != null)
 			listeners.remove(streamPlayerListener);
@@ -259,6 +262,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @throws StreamPlayerException the stream player exception
 	 */
+	@Override
 	public void open(final Object object) throws StreamPlayerException {
 
 		logger.info(() -> "open(" + object + ")\n");
@@ -407,6 +411,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param speedFactor speedFactor
 	 */
+	@Override
 	public void setSpeedFactor(final double speedFactor) {
 		this.speedFactor = speedFactor;
 
@@ -556,6 +561,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @throws StreamPlayerException the stream player exception
 	 */
+	@Override
 	public void play() throws StreamPlayerException {
 		if (status == Status.STOPPED)
 			initAudioInputStream();
@@ -593,6 +599,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return true, if successful
 	 */
+	@Override
 	public boolean pause() {
 		if (outlet.getSourceDataLine() == null || status != Status.PLAYING)
 			return false;
@@ -608,6 +615,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * Player Status = STOPPED.<br>
 	 * Thread should free Audio resources.
 	 */
+	@Override
 	public void stop() {
 		if (status == Status.STOPPED)
 			return;
@@ -625,6 +633,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return False if failed(so simple...)
 	 */
+	@Override
 	public boolean resume() {
 		if (outlet.getSourceDataLine() == null || status != Status.PAUSED)
 			return false;
@@ -686,6 +695,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @throws StreamPlayerException the stream player exception
 	 */
+	@Override
 	public long seekBytes(final long bytes) throws StreamPlayerException {
 		long totalSkipped = 0;
 
@@ -748,6 +758,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param seconds Seconds to Skip
 	 */
+	@Override
 	//todo not finished needs more validations
 	public long seekSeconds(int seconds) throws StreamPlayerException {
 		int durationInSeconds = this.getDurationInSeconds();
@@ -781,6 +792,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param seconds Seconds to Skip
 	 */
+	@Override
 	public long seekTo(int seconds) throws StreamPlayerException {
 		int durationInSeconds = this.getDurationInSeconds();
 
@@ -815,6 +827,8 @@ public class StreamPlayer implements Callable<Void> {
 		}
 	}
 
+
+	@Override
 	public int getDurationInSeconds() {
 
 		// Audio resources from file||URL||inputStream.
@@ -968,6 +982,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Position of the encoded stream in term of bytes
 	 */
+	@Override
 	public int getEncodedStreamPosition() {
 		int position = -1;
 		if (dataSource instanceof File && encodedAudioInputStream != null)
@@ -999,6 +1014,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return -1 maximum buffer size.
 	 */
+	@Override
 	public int getLineBufferSize() {
 		return lineBufferSize;
 	}
@@ -1008,6 +1024,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The current line buffer size
 	 */
+	@Override
 	public int getLineCurrentBufferSize() {
 		return currentLineBufferSize;
 	}
@@ -1017,6 +1034,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return A List of available Mixers
 	 */
+	@Override
 	public List<String> getMixers() {
 		final List<String> mixers = new ArrayList<>();
 
@@ -1079,6 +1097,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Gain Value
 	 */
+	@Override
 	public float getGainValue() {
 
 		if (hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
@@ -1093,6 +1112,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Maximum Gain Value
 	 */
+	@Override
 	public float getMaximumGain() {
 		return !hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMaximum();
 
@@ -1103,6 +1123,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Minimum Gain Value
 	 */
+	@Override
 	public float getMinimumGain() {
 
 		return !hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMinimum();
@@ -1114,6 +1135,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Precision Value
 	 */
+	@Override
 	public float getPrecision() {
 		return !hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getPrecision();
 
@@ -1124,6 +1146,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Pan Value
 	 */
+	@Override
 	public float getPan() {
 		return !hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getValue();
 
@@ -1134,6 +1157,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return True if muted , False if not
 	 */
+	@Override
 	public boolean getMute() {
 		return hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue();
 	}
@@ -1143,6 +1167,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Balance Value
 	 */
+	@Override
 	public float getBalance() {
 		return !hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) ? 0f : outlet.getBalanceControl().getValue();
 	}
@@ -1152,6 +1177,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return encodedAudioLength
 	 */
+	@Override
 	public long getTotalBytes() {
 		return encodedAudioLength;
 	}
@@ -1169,6 +1195,7 @@ public class StreamPlayer implements Callable<Void> {
 	/**
 	 * @return BytePosition
 	 */
+	@Override
 	public int getPositionByte() {
 		final int positionByte = AudioSystem.NOT_SPECIFIED;
 		if (audioProperties != null) {
@@ -1190,6 +1217,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return The Player Status
 	 */
+	@Override
 	public Status getStatus() {
 		return status;
 	}
@@ -1214,6 +1242,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param size -1 means maximum buffer size available.
 	 */
+	@Override
 	public void setLineBufferSize(final int size) {
 		lineBufferSize = size;
 	}
@@ -1224,6 +1253,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param fPan the new pan
 	 */
+	@Override
 	public void setPan(final double fPan) {
 
 		if (!hasControl(FloatControl.Type.PAN, outlet.getPanControl()) || fPan < -1.0 || fPan > 1.0)
@@ -1240,6 +1270,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param fGain The new gain value
 	 */
+	@Override
 	public void setGain(final double fGain) {
 		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
             final double logScaleGain = 20 * Math.log10(fGain);
@@ -1247,6 +1278,7 @@ public class StreamPlayer implements Callable<Void> {
         }
 	}
 
+	@Override
 	public void setLogScaleGain(final double logScaleGain) {
 		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
 			outlet.getGainControl().setValue((float) logScaleGain);
@@ -1258,6 +1290,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param mute True to mute the audio of False to unmute it
 	 */
+	@Override
 	public void setMute(final boolean mute) {
 		if (hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue() != mute)
 			outlet.getMuteControl().setValue(mute);
@@ -1270,6 +1303,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @param fBalance the new balance
 	 */
+	@Override
 	public void setBalance(final float fBalance) {
 		if (hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) && fBalance >= -1.0 && fBalance <= 1.0)
 			outlet.getBalanceControl().setValue(fBalance);
@@ -1287,6 +1321,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @param array the array
 	 * @param stop the stop
 	 */
+	@Override
 	public void setEqualizer(final float[] array, final int stop) {
 		if (!isPausedOrPlaying() || !(audioInputStream instanceof PropertiesContainer))
 			return;
@@ -1302,6 +1337,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @param value the value
 	 * @param key the key
 	 */
+	@Override
 	public void setEqualizerKey(final float value, final int key) {
 		if (!isPausedOrPlaying() || !(audioInputStream instanceof PropertiesContainer))
 			return;
@@ -1314,6 +1350,7 @@ public class StreamPlayer implements Callable<Void> {
 	/**
 	 * @return The Speech Factor of the Audio
 	 */
+	@Override
 	public double getSpeedFactor() {
 		return this.speedFactor;
 	}
@@ -1323,6 +1360,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return If Status==STATUS.UNKNOWN.
 	 */
+	@Override
 	public boolean isUnknown() {
 		return status == Status.NOT_SPECIFIED;
 	}
@@ -1332,6 +1370,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return <b>true</b> if player is playing ,<b>false</b> if not.
 	 */
+	@Override
 	public boolean isPlaying() {
 		return status == Status.PLAYING;
 	}
@@ -1341,6 +1380,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return <b>true</b> if player is paused ,<b>false</b> if not.
 	 */
+	@Override
 	public boolean isPaused() {
 		return status == Status.PAUSED;
 	}
@@ -1350,6 +1390,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return <b>true</b> if player is paused/playing,<b>false</b> if not
 	 */
+	@Override
 	public boolean isPausedOrPlaying() {
 		return isPlaying() || isPaused();
 	}
@@ -1359,6 +1400,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return <b>true</b> if player is stopped ,<b>false</b> if not
 	 */
+	@Override
 	public boolean isStopped() {
 		return status == Status.STOPPED;
 	}
@@ -1368,6 +1410,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return <b>true</b> if player is opened ,<b>false</b> if not
 	 */
+	@Override
 	public boolean isOpened() {
 		return status == Status.OPENED;
 	}
@@ -1377,6 +1420,7 @@ public class StreamPlayer implements Callable<Void> {
 	 *
 	 * @return <b>true</b> if player is seeking ,<b>false</b> if not
 	 */
+	@Override
 	public boolean isSeeking() {
 		return status == Status.SEEKING;
 	}
@@ -1385,6 +1429,7 @@ public class StreamPlayer implements Callable<Void> {
 		return logger;
 	}
 
+	@Override
 	public SourceDataLine getSourceDataLine() {
 		return outlet.getSourceDataLine();
 	}

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -186,7 +186,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 			closeStream();
 		}
 
-		outlet.stopAndFreeDataLine();
+		outlet.flushAndFreeDataLine();
 
 		// AudioFile
 		audioInputStream = null;
@@ -759,17 +759,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		return seekBytes(bytes);
 	}
 
-//	/**
-//	 * Go to X time of the Audio
-//	 * See  {@link #seek(long)}
-//	 *
-//	 * @param pattern A string in the format (HH:MM:SS) WHERE h = HOURS , M = minutes , S = seconds
-//	 */
-//	public void seekTo(String pattern) throws StreamPlayerException {
-//		long bytes = 0;
-//
-//		seek(bytes);
-//	}
 
 	private void validateSeconds(int seconds, int durationInSeconds) {
 		if (seconds < 0) {
@@ -851,8 +840,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 
 							// Compute position in bytes in encoded stream.
 							final int nEncodedBytes = getEncodedStreamPosition();
-
-							// System.err.println(trimBuffer[0] + " , Data Length :" + trimBuffer.length)
 
 							// Notify all registered Listeners
 							listeners.forEach(listener -> {
@@ -1102,16 +1089,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	public long getTotalBytes() {
 		return encodedAudioLength;
 	}
-
-	/**
-	 * @return
-	 */
-	// public int getByteLength() {
-	// return audioProperties == null ||
-	// !audioProperties.containsKey("audio.length.bytes") ?
-	// AudioSystem.NOT_SPECIFIED
-	// : ((Integer) audioProperties.get("audio.length.bytes")).intValue();
-	// }
 
 	/**
 	 * @return BytePosition

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -34,8 +34,6 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.BooleanControl;
-import javax.sound.sampled.Control;
-import javax.sound.sampled.Control.Type;
 import javax.sound.sampled.DataLine;
 import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.Line;
@@ -1081,18 +1079,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	}
 
 	/**
-	 * Check if the <b>Control</b> is Supported by m_line.
-	 *
-	 * @param control the control
-	 * @param component the component
-	 *
-	 * @return true, if successful
-	 */
-	public boolean hasControl(final Type control, final Control component) {
-		return component != null && (outlet.getSourceDataLine() != null) && (outlet.getSourceDataLine().isControlSupported(control));
-	}
-
-	/**
 	 * Returns Gain value.
 	 *
 	 * @return The Gain Value
@@ -1100,7 +1086,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	@Override
 	public float getGainValue() {
 
-		if (hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
+		if (outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this)) {
 			return outlet.getGainControl().getValue();
         } else {
             return 0.0F;
@@ -1114,7 +1100,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getMaximumGain() {
-		return !hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMaximum();
+		return !outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this) ? 0.0F : outlet.getGainControl().getMaximum();
 
 	}
 
@@ -1126,7 +1112,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	@Override
 	public float getMinimumGain() {
 
-		return !hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMinimum();
+		return !outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this) ? 0.0F : outlet.getGainControl().getMinimum();
 
 	}
 
@@ -1137,7 +1123,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getPrecision() {
-		return !hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getPrecision();
+		return !outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl(), this) ? 0.0F : outlet.getPanControl().getPrecision();
 
 	}
 
@@ -1148,7 +1134,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getPan() {
-		return !hasControl(FloatControl.Type.PAN, outlet.getPanControl()) ? 0.0F : outlet.getPanControl().getValue();
+		return !outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl(), this) ? 0.0F : outlet.getPanControl().getValue();
 
 	}
 
@@ -1159,7 +1145,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public boolean getMute() {
-		return hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue();
+		return outlet.hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl(), this) && outlet.getMuteControl().getValue();
 	}
 
 	/**
@@ -1169,7 +1155,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public float getBalance() {
-		return !hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) ? 0f : outlet.getBalanceControl().getValue();
+		return !outlet.hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl(), this) ? 0f : outlet.getBalanceControl().getValue();
 	}
 
 	/****
@@ -1256,7 +1242,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	@Override
 	public void setPan(final double fPan) {
 
-		if (!hasControl(FloatControl.Type.PAN, outlet.getPanControl()) || fPan < -1.0 || fPan > 1.0)
+		if (!outlet.hasControl(FloatControl.Type.PAN, outlet.getPanControl(), this) || fPan < -1.0 || fPan > 1.0)
 			return;
 		logger.info(() -> "Pan : " + fPan);
 		outlet.getPanControl().setValue((float) fPan);
@@ -1272,7 +1258,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void setGain(final double fGain) {
-		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
+		if (isPlaying() || isPaused() && outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this)) {
             final double logScaleGain = 20 * Math.log10(fGain);
 			outlet.getGainControl().setValue((float) logScaleGain);
         }
@@ -1280,7 +1266,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 
 	@Override
 	public void setLogScaleGain(final double logScaleGain) {
-		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
+		if (isPlaying() || isPaused() && outlet.hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl(), this)) {
 			outlet.getGainControl().setValue((float) logScaleGain);
 		}
 	}
@@ -1292,7 +1278,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void setMute(final boolean mute) {
-		if (hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue() != mute)
+		if (outlet.hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl(), this) && outlet.getMuteControl().getValue() != mute)
 			outlet.getMuteControl().setValue(mute);
 	}
 
@@ -1305,7 +1291,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void setBalance(final float fBalance) {
-		if (hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) && fBalance >= -1.0 && fBalance <= 1.0)
+		if (outlet.hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl(), this) && fBalance >= -1.0 && fBalance <= 1.0)
 			outlet.getBalanceControl().setValue(fBalance);
 		else
 			try {

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -95,7 +95,7 @@ public class StreamPlayer implements Callable<Void> {
 	private FloatControl panControl;
 
 	/** The balance control. */
-	private FloatControl balanceControl;
+//	private FloatControl balanceControl;
 
 	/** The sample rate control. */
 	// private FloatControl sampleRateControl
@@ -223,7 +223,7 @@ public class StreamPlayer implements Callable<Void> {
 		// Controls
 		outlet.setGainControl(null);
 		panControl = null;
-		balanceControl = null;
+		outlet.setBalanceControl(null);
 		// sampleRateControl = null
 
 		// Notify the Status
@@ -559,9 +559,10 @@ public class StreamPlayer implements Callable<Void> {
 					: null;
 
 				// Speakers Balance?
-				balanceControl = sourceDataLine.isControlSupported(FloatControl.Type.BALANCE)
+				FloatControl balanceControl = sourceDataLine.isControlSupported(FloatControl.Type.BALANCE)
 					? (FloatControl) sourceDataLine.getControl(FloatControl.Type.BALANCE)
 					: null;
+				outlet.setBalanceControl(balanceControl);
 			}
 
 		}
@@ -1162,7 +1163,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @return The Balance Value
 	 */
 	public float getBalance() {
-		return !hasControl(FloatControl.Type.BALANCE, balanceControl) ? 0f : balanceControl.getValue();
+		return !hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) ? 0f : outlet.getBalanceControl().getValue();
 	}
 
 	/****
@@ -1293,8 +1294,8 @@ public class StreamPlayer implements Callable<Void> {
 	 * @param fBalance the new balance
 	 */
 	public void setBalance(final float fBalance) {
-		if (hasControl(FloatControl.Type.BALANCE, balanceControl) && fBalance >= -1.0 && fBalance <= 1.0)
-			balanceControl.setValue(fBalance);
+		if (hasControl(FloatControl.Type.BALANCE, outlet.getBalanceControl()) && fBalance >= -1.0 && fBalance <= 1.0)
+			outlet.getBalanceControl().setValue(fBalance);
 		else
 			try {
 				throw new StreamPlayerException(PlayerException.BALANCE_CONTROL_NOT_SUPPORTED);

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -85,12 +85,7 @@ public class StreamPlayer implements Callable<Void> {
 
 	/** The source data line. */
 	private SourceDataLine sourceDataLine;
-
-	// -------------------CONTROLS---------------------
-
-	/** The mute control. */
-	private BooleanControl muteControl;
-
+	
 	// -------------------LOCKS---------------------
 
 	/**
@@ -542,9 +537,10 @@ public class StreamPlayer implements Callable<Void> {
 				// sampleRateControl = null
 
 				// Mute?
-				muteControl = sourceDataLine.isControlSupported(BooleanControl.Type.MUTE)
+				BooleanControl muteControl1 = sourceDataLine.isControlSupported(BooleanControl.Type.MUTE)
 					? (BooleanControl) sourceDataLine.getControl(BooleanControl.Type.MUTE)
 					: null;
+				outlet.setMuteControl(muteControl1);
 
 				// Speakers Balance?
 				FloatControl balanceControl = sourceDataLine.isControlSupported(FloatControl.Type.BALANCE)
@@ -1142,7 +1138,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @return True if muted , False if not
 	 */
 	public boolean getMute() {
-		return hasControl(BooleanControl.Type.MUTE, muteControl) && muteControl.getValue();
+		return hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue();
 	}
 
 	/**
@@ -1270,8 +1266,8 @@ public class StreamPlayer implements Callable<Void> {
 	 * @param mute True to mute the audio of False to unmute it
 	 */
 	public void setMute(final boolean mute) {
-		if (hasControl(BooleanControl.Type.MUTE, muteControl) && muteControl.getValue() != mute)
-			muteControl.setValue(mute);
+		if (hasControl(BooleanControl.Type.MUTE, outlet.getMuteControl()) && outlet.getMuteControl().getValue() != mute)
+			outlet.getMuteControl().setValue(mute);
 	}
 
 	/**

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -925,7 +925,9 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 						}
 
 					} else if (status == Status.PAUSED) {
-						flushAndStopOutlet();
+						// Flush and stop the source data line
+						outlet.flushAndStop();
+						goOutOfPause();
 
 					}
 				} catch (final IOException ex) {
@@ -955,12 +957,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		return null;
 	}
 
-	private void flushAndStopOutlet() {
-		// Flush and stop the source data line
-		if (outlet.getSourceDataLine() != null && outlet.getSourceDataLine().isRunning()) {
-			outlet.getSourceDataLine().flush();
-			outlet.getSourceDataLine().stop();
-		}
+	private void goOutOfPause() {
 		try {
 			while (status == Status.PAUSED) {
 				Thread.sleep(50);

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -198,7 +198,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		outlet.setGainControl(null);
 		outlet.setPanControl(null);
 		outlet.setBalanceControl(null);
-		// sampleRateControl = null
 
 		// Notify the Status
 		status = Status.NOT_SPECIFIED;
@@ -365,7 +364,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		audioProperties.put("basicplayer.sourcedataline", outlet.getSourceDataLine());
 
 		// Keep this final reference for the lambda expression
-		final Map<String, Object> audioPropertiesCopy = audioProperties;
+		final Map<String, Object> audioPropertiesCopy = audioProperties; // TODO: Remove, it's meaningless.
 
 		// Notify all registered StreamPlayerListeners
 		listeners.forEach(listener -> listener.opened(dataSource, audioPropertiesCopy));
@@ -502,45 +501,33 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 
 		logger.info("Entered OpenLine()!:\n");
 
-		final SourceDataLine sourceDataLine = outlet.getSourceDataLine();
-		if (sourceDataLine != null) {
+		if (outlet.getSourceDataLine() != null) {
 			final AudioFormat audioFormat = audioInputStream.getFormat();
-			currentLineBufferSize = lineBufferSize >= 0 ? lineBufferSize : sourceDataLine.getBufferSize();
-			sourceDataLine.open(audioFormat, currentLineBufferSize);
+			currentLineBufferSize = lineBufferSize >= 0 ? lineBufferSize : outlet.getSourceDataLine().getBufferSize();
+			outlet.getSourceDataLine().open(audioFormat, currentLineBufferSize);
 
 			// opened?
-			if (sourceDataLine.isOpen()) {
-				// logger.info(() -> "Open Line Buffer Size=" + bufferSize + "\n");
-
-				/*-- Display supported controls --*/
-				// Control[] c = m_line.getControls()
+			if (outlet.getSourceDataLine().isOpen()) {
 
 				// Master_Gain Control?
-				if (sourceDataLine.isControlSupported(FloatControl.Type.MASTER_GAIN))
-					outlet.setGainControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.MASTER_GAIN));
+				if (outlet.getSourceDataLine().isControlSupported(FloatControl.Type.MASTER_GAIN))
+					outlet.setGainControl((FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.MASTER_GAIN));
 				else outlet.setGainControl(null);
 
 				// PanControl?
-				if (sourceDataLine.isControlSupported(FloatControl.Type.PAN))
-					outlet.setPanControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.PAN));
+				if (outlet.getSourceDataLine().isControlSupported(FloatControl.Type.PAN))
+					outlet.setPanControl((FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.PAN));
 				else outlet.setPanControl(null);
 
-				// SampleRate?
-				// if (sourceDataLine.isControlSupported(FloatControl.Type.SAMPLE_RATE))
-				// sampleRateControl = (FloatControl)
-				// sourceDataLine.getControl(FloatControl.Type.SAMPLE_RATE);
-				// else
-				// sampleRateControl = null
-
 				// Mute?
-				BooleanControl muteControl1 = sourceDataLine.isControlSupported(BooleanControl.Type.MUTE)
-					? (BooleanControl) sourceDataLine.getControl(BooleanControl.Type.MUTE)
+				BooleanControl muteControl1 = outlet.getSourceDataLine().isControlSupported(BooleanControl.Type.MUTE)
+					? (BooleanControl) outlet.getSourceDataLine().getControl(BooleanControl.Type.MUTE)
 					: null;
 				outlet.setMuteControl(muteControl1);
 
 				// Speakers Balance?
-				FloatControl balanceControl = sourceDataLine.isControlSupported(FloatControl.Type.BALANCE)
-					? (FloatControl) sourceDataLine.getControl(FloatControl.Type.BALANCE)
+				FloatControl balanceControl = outlet.getSourceDataLine().isControlSupported(FloatControl.Type.BALANCE)
+					? (FloatControl) outlet.getSourceDataLine().getControl(FloatControl.Type.BALANCE)
 					: null;
 				outlet.setBalanceControl(balanceControl);
 			}

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -89,7 +89,7 @@ public class StreamPlayer implements Callable<Void> {
 	// -------------------CONTROLS---------------------
 
 	/** The gain control. */
-	private FloatControl gainControl;
+	//private FloatControl gainControl;
 
 	/** The pan control. */
 	private FloatControl panControl;
@@ -221,7 +221,7 @@ public class StreamPlayer implements Callable<Void> {
 		encodedAudioLength = -1;
 
 		// Controls
-		setGainControl(null);
+		outlet.setGainControl(null);
 		panControl = null;
 		balanceControl = null;
 		// sampleRateControl = null
@@ -538,8 +538,8 @@ public class StreamPlayer implements Callable<Void> {
 
 				// Master_Gain Control?
 				if (sourceDataLine.isControlSupported(FloatControl.Type.MASTER_GAIN))
-					setGainControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.MASTER_GAIN));
-				else setGainControl(null);
+					outlet.setGainControl((FloatControl) sourceDataLine.getControl(FloatControl.Type.MASTER_GAIN));
+				else outlet.setGainControl(null);
 
 				// PanControl?
 				if (sourceDataLine.isControlSupported(FloatControl.Type.PAN))
@@ -1099,8 +1099,8 @@ public class StreamPlayer implements Callable<Void> {
 	 */
 	public float getGainValue() {
 
-        if (hasControl(FloatControl.Type.MASTER_GAIN, getGainControl())) {
-            return getGainControl().getValue();
+		if (hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
+			return outlet.getGainControl().getValue();
         } else {
             return 0.0F;
         }
@@ -1112,7 +1112,7 @@ public class StreamPlayer implements Callable<Void> {
 	 * @return The Maximum Gain Value
 	 */
 	public float getMaximumGain() {
-		return !hasControl(FloatControl.Type.MASTER_GAIN, getGainControl()) ? 0.0F : getGainControl().getMaximum();
+		return !hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMaximum();
 
 	}
 
@@ -1123,7 +1123,7 @@ public class StreamPlayer implements Callable<Void> {
 	 */
 	public float getMinimumGain() {
 
-		return !hasControl(FloatControl.Type.MASTER_GAIN, getGainControl()) ? 0.0F : getGainControl().getMinimum();
+		return !hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl()) ? 0.0F : outlet.getGainControl().getMinimum();
 
 	}
 
@@ -1263,15 +1263,15 @@ public class StreamPlayer implements Callable<Void> {
 	 * @param fGain The new gain value
 	 */
 	public void setGain(final double fGain) {
-		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, getGainControl())) {
+		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
             final double logScaleGain = 20 * Math.log10(fGain);
-            getGainControl().setValue((float) logScaleGain);
+			outlet.getGainControl().setValue((float) logScaleGain);
         }
 	}
 
 	public void setLogScaleGain(final double logScaleGain) {
-		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, getGainControl())) {
-			getGainControl().setValue((float) logScaleGain);
+		if (isPlaying() || isPaused() && hasControl(FloatControl.Type.MASTER_GAIN, outlet.getGainControl())) {
+			outlet.getGainControl().setValue((float) logScaleGain);
 		}
 	}
 
@@ -1407,12 +1407,4 @@ public class StreamPlayer implements Callable<Void> {
 		return logger;
 	}
 
-	/** The gain control. */
-	public FloatControl getGainControl() {
-		return gainControl;
-	}
-
-	public void setGainControl(FloatControl gainControl) {
-		this.gainControl = gainControl;
-	}
 }

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -185,13 +185,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		synchronized (audioLock) {
 			closeStream();
 		}
-
-		// Source Data Line
-		if (outlet.getSourceDataLine() != null) {
-			outlet.getSourceDataLine().flush();
-			outlet.getSourceDataLine().close();
-			outlet.setSourceDataLine(null);
-		}
+		resetOutlet();
 
 		// AudioFile
 		audioInputStream = null;
@@ -200,15 +194,27 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		encodedAudioLength = -1;
 
 		// Controls
-		outlet.setGainControl(null);
-		outlet.setPanControl(null);
-		outlet.setBalanceControl(null);
-		// sampleRateControl = null
+		resetControls();
 
 		// Notify the Status
 		status = Status.NOT_SPECIFIED;
 		generateEvent(Status.NOT_SPECIFIED, AudioSystem.NOT_SPECIFIED, null);
 
+	}
+
+	private void resetControls() {
+		outlet.setGainControl(null);
+		outlet.setPanControl(null);
+		outlet.setBalanceControl(null);
+	}
+
+	private void resetOutlet() {
+		// Source Data Line
+		if (outlet.getSourceDataLine() != null) {
+			outlet.getSourceDataLine().flush();
+			outlet.getSourceDataLine().close();
+			outlet.setSourceDataLine(null);
+		}
 	}
 
 	/**

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
@@ -108,17 +108,6 @@ public interface StreamPlayerInterface {
 
     int getDurationInSeconds();
 
-//    /**
-//     * Main loop.
-//     * <p>
-//     * Player Status == STOPPED || SEEKING = End of Thread + Freeing Audio
-//     * Resources.<br>
-//     * Player Status == PLAYING = Audio stream data sent to Audio line.<br>
-//     * Player Status == PAUSED = Waiting for another status.
-//     */
-//    @Override
-//    Void call();
-
     /**
      * Calculates the current position of the encoded audio based on <br>
      * <b>nEncodedBytes = encodedAudioLength -
@@ -198,7 +187,7 @@ public interface StreamPlayerInterface {
      */
     float getBalance();
 
-    /****
+    /**
      * Return the total size of this file in bytes.
      *
      * @return encodedAudioLength

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
@@ -1,0 +1,338 @@
+package com.goxr3plus.streamplayer.stream;
+
+import com.goxr3plus.streamplayer.enums.Status;
+
+import javax.sound.sampled.SourceDataLine;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public interface StreamPlayerInterface {
+    /**
+     * Freeing the resources.
+     */
+    void reset();
+
+    /**
+     * Add a listener to be notified.
+     *
+     * @param streamPlayerListener the listener
+     */
+    void addStreamPlayerListener(StreamPlayerListener streamPlayerListener);
+
+    /**
+     * Remove registered listener.
+     *
+     * @param streamPlayerListener the listener
+     */
+    void removeStreamPlayerListener(StreamPlayerListener streamPlayerListener);
+
+    /**
+     * Open the specific object which can be File,URL or InputStream.
+     *
+     * @param object the object [File or URL or InputStream ]
+     *
+     * @throws StreamPlayerException the stream player exception
+     */
+    void open(Object object) throws StreamPlayerException;
+
+    /**
+     * Change the Speed Rate of the Audio , this variable affects the Sample Rate ,
+     * for example 1.0 is normal , 0.5 is half the speed and 2.0 is double the speed
+     * Note that you have to restart the audio for this to take effect
+     *
+     * @param speedFactor speedFactor
+     */
+    void setSpeedFactor(double speedFactor);
+
+    /**
+     * Starts the play back.
+     *
+     * @throws StreamPlayerException the stream player exception
+     */
+    void play() throws StreamPlayerException;
+
+    /**
+     * Pauses the play back.<br>
+     * <p>
+     * Player Status = PAUSED. * @return False if failed(so simple...)
+     *
+     * @return true, if successful
+     */
+    boolean pause();
+
+    /**
+     * Stops the play back.<br>
+     * <p>
+     * Player Status = STOPPED.<br>
+     * Thread should free Audio resources.
+     */
+    void stop();
+
+    /**
+     * Resumes the play back.<br>
+     * <p>
+     * Player Status = PLAYING*
+     *
+     * @return False if failed(so simple...)
+     */
+    boolean resume();
+
+    /**
+     * Skip bytes in the File input stream. It will skip N frames matching to bytes,
+     * so it will never skip given bytes len
+     *
+     * @param bytes the bytes
+     *
+     * @return value bigger than 0 for File and value = 0 for URL and InputStream
+     *
+     * @throws StreamPlayerException the stream player exception
+     */
+    long seekBytes(long bytes) throws StreamPlayerException;
+
+    /**
+     * Skip x seconds of audio
+     * See  {@link #seekBytes(long)}
+     *
+     * @param seconds Seconds to Skip
+     */
+    //todo not finished needs more validations
+    long seekSeconds(int seconds) throws StreamPlayerException;
+
+    /**
+     * Go to X time of the Audio
+     * See  {@link #seekBytes(long)}
+     *
+     * @param seconds Seconds to Skip
+     */
+    long seekTo(int seconds) throws StreamPlayerException;
+
+    int getDurationInSeconds();
+
+//    /**
+//     * Main loop.
+//     * <p>
+//     * Player Status == STOPPED || SEEKING = End of Thread + Freeing Audio
+//     * Resources.<br>
+//     * Player Status == PLAYING = Audio stream data sent to Audio line.<br>
+//     * Player Status == PAUSED = Waiting for another status.
+//     */
+//    @Override
+//    Void call();
+
+    /**
+     * Calculates the current position of the encoded audio based on <br>
+     * <b>nEncodedBytes = encodedAudioLength -
+     * encodedAudioInputStream.available();</b>
+     *
+     * @return The Position of the encoded stream in term of bytes
+     */
+    int getEncodedStreamPosition();
+
+    /**
+     * Return SourceDataLine buffer size.
+     *
+     * @return -1 maximum buffer size.
+     */
+    int getLineBufferSize();
+
+    /**
+     * Return SourceDataLine current buffer size.
+     *
+     * @return The current line buffer size
+     */
+    int getLineCurrentBufferSize();
+
+    /**
+     * Returns all available mixers.
+     *
+     * @return A List of available Mixers
+     */
+    List<String> getMixers();
+
+    /**
+     * Returns Gain value.
+     *
+     * @return The Gain Value
+     */
+    float getGainValue();
+
+    /**
+     * Returns maximum Gain value.
+     *
+     * @return The Maximum Gain Value
+     */
+    float getMaximumGain();
+
+    /**
+     * Returns minimum Gain value.
+     *
+     * @return The Minimum Gain Value
+     */
+    float getMinimumGain();
+
+    /**
+     * Returns Pan precision.
+     *
+     * @return The Precision Value
+     */
+    float getPrecision();
+
+    /**
+     * Returns Pan value.
+     *
+     * @return The Pan Value
+     */
+    float getPan();
+
+    /**
+     * Return the mute Value(true || false).
+     *
+     * @return True if muted , False if not
+     */
+    boolean getMute();
+
+    /**
+     * Return the balance Value.
+     *
+     * @return The Balance Value
+     */
+    float getBalance();
+
+    /****
+     * Return the total size of this file in bytes.
+     *
+     * @return encodedAudioLength
+     */
+    long getTotalBytes();
+
+    /**
+     * @return BytePosition
+     */
+    int getPositionByte();
+
+    /**
+     * Gets the source data line.
+     *
+     * @return The SourceDataLine
+     */
+    SourceDataLine getSourceDataLine();
+
+    /**
+     * This method will return the status of the player
+     *
+     * @return The Player Status
+     */
+    Status getStatus();
+
+    /**
+     * Set SourceDataLine buffer size. It affects audio latency. (the delay between
+     * line.write(data) and real sound). Minimum value should be over 10000 bytes.
+     *
+     * @param size -1 means maximum buffer size available.
+     */
+    void setLineBufferSize(int size);
+
+    /**
+     * Sets Pan value. Line should be opened before calling this method. Linear
+     * scale : -1.0 ... +1.0
+     *
+     * @param fPan the new pan
+     */
+    void setPan(double fPan);
+
+    /**
+     * Sets Gain value. Line should be opened before calling this method. Linear
+     * scale 0.0 ... 1.0 Threshold Coef. : 1/2 to avoid saturation.
+     *
+     * @param fGain The new gain value
+     */
+    void setGain(double fGain);
+
+    void setLogScaleGain(double logScaleGain);
+
+    /**
+     * Set the mute of the Line. Note that mute status does not affect gain.
+     *
+     * @param mute True to mute the audio of False to unmute it
+     */
+    void setMute(boolean mute);
+
+    /**
+     * Represents a control for the relative balance of a stereo signal between two
+     * stereo speakers. The valid range of values is -1.0 (left channel only) to 1.0
+     * (right channel only). The default is 0.0 (centered).
+     *
+     * @param fBalance the new balance
+     */
+    void setBalance(float fBalance);
+
+    /**
+     * Changes specific values from equalizer.
+     *
+     * @param array the array
+     * @param stop the stop
+     */
+    void setEqualizer(float[] array, int stop);
+
+    /**
+     * Changes a value from equalizer.
+     *
+     * @param value the value
+     * @param key the key
+     */
+    void setEqualizerKey(float value, int key);
+
+    /**
+     * @return The Speech Factor of the Audio
+     */
+    double getSpeedFactor();
+
+    /**
+     * Checks if is unknown.
+     *
+     * @return If Status==STATUS.UNKNOWN.
+     */
+    boolean isUnknown();
+
+    /**
+     * Checks if is playing.
+     *
+     * @return <b>true</b> if player is playing ,<b>false</b> if not.
+     */
+    boolean isPlaying();
+
+    /**
+     * Checks if is paused.
+     *
+     * @return <b>true</b> if player is paused ,<b>false</b> if not.
+     */
+    boolean isPaused();
+
+    /**
+     * Checks if is paused or playing.
+     *
+     * @return <b>true</b> if player is paused/playing,<b>false</b> if not
+     */
+    boolean isPausedOrPlaying();
+
+    /**
+     * Checks if is stopped.
+     *
+     * @return <b>true</b> if player is stopped ,<b>false</b> if not
+     */
+    boolean isStopped();
+
+    /**
+     * Checks if is opened.
+     *
+     * @return <b>true</b> if player is opened ,<b>false</b> if not
+     */
+    boolean isOpened();
+
+    /**
+     * Checks if is seeking.
+     *
+     * @return <b>true</b> if player is seeking ,<b>false</b> if not
+     */
+    boolean isSeeking();
+}

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 
 import static java.lang.Math.log10;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 public class SourceDataLineTest {
@@ -113,5 +114,25 @@ public class SourceDataLineTest {
         // Verify
         assertEquals(0, initialBalance);
         assertEquals(wantedBalance, actualBalance);
+    }
+
+    @Test
+    void pan() throws StreamPlayerException {
+        double delta = 1e-6;
+        final float initialPan = player.getPan();
+        assertEquals(0, initialPan);
+
+        player.open(audioFile);
+        player.play();
+
+        double pan = -0.9;
+        player.setPan(pan);
+        assertEquals(pan, player.getPan(), delta);
+
+        double outsideRange = 1.1;
+        player.setPan(outsideRange);
+        assertEquals(pan, player.getPan(), delta);
+
+//        fail("Test not done");
     }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -178,13 +178,13 @@ public class SourceDataLineTest {
         player.open(audioFile);
         player.play();
         player.seekTo(30);
-        if (listen) Thread.sleep(2000);
+        if (listen) Thread.sleep(200);
 
         player.pause();
-        if (listen) Thread.sleep(1000);
+        if (listen) Thread.sleep(100);
 
         player.resume();  // TODO: Examine what happens if play() is called instead.
-        if (listen) Thread.sleep(2000);
+        if (listen) Thread.sleep(200);
         //player.stop();
 
         // TODO: asserts and listen=false

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -169,4 +169,23 @@ public class SourceDataLineTest {
 
         assertNotNull(player.getSourceDataLine());
     }
+
+    @Test
+   // @Timeout(1)
+    void reset() throws StreamPlayerException {
+
+        assertNull(player.getSourceDataLine());
+
+        player.open(audioFile);
+        assertNotNull(player.getSourceDataLine());
+
+//        player.play();
+//        assertNotNull(player.getSourceDataLine());
+
+        player.reset();
+        assertNull(player.getSourceDataLine());
+        player.stop();
+
+
+    }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -1,5 +1,6 @@
 package com.goxr3plus.streamplayer.stream;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -7,8 +8,7 @@ import java.io.File;
 import java.util.logging.Logger;
 
 import static java.lang.Math.log10;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class SourceDataLineTest {
@@ -21,6 +21,11 @@ public class SourceDataLineTest {
         final Logger logger = mock(Logger.class);
         player = new StreamPlayer(logger);
         audioFile = new File("Logic - Ballin [Bass Boosted].mp3");
+    }
+
+    @AfterEach
+    void tearDown() {
+        player.stop();
     }
 
     @Test
@@ -132,7 +137,23 @@ public class SourceDataLineTest {
         double outsideRange = 1.1;
         player.setPan(outsideRange);
         assertEquals(pan, player.getPan(), delta);
+    }
 
-//        fail("Test not done");
+    @Test
+    void mute() throws StreamPlayerException {
+        assertFalse(player.getMute());
+        player.setMute(true);
+        assertFalse(player.getMute());
+        player.open(audioFile);
+        player.setMute(true);
+        assertFalse(player.getMute());
+
+        player.play();
+        player.setMute(true);
+        assertTrue(player.getMute()); // setMute works only after play() has been called.
+
+
+        player.setMute(false);
+        assertFalse(player.getMute());
     }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.sound.sampled.SourceDataLine;
 import java.io.File;
 import java.util.logging.Logger;
 
@@ -155,5 +156,17 @@ public class SourceDataLineTest {
 
         player.setMute(false);
         assertFalse(player.getMute());
+    }
+
+    @Test
+    void sourceDataLine() throws StreamPlayerException {
+        assertNull(player.getSourceDataLine());
+
+        player.open(audioFile);
+        assertNotNull(player.getSourceDataLine());
+
+        player.play();
+
+        assertNotNull(player.getSourceDataLine());
     }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -169,23 +169,4 @@ public class SourceDataLineTest {
 
         assertNotNull(player.getSourceDataLine());
     }
-
-    @Test
-   // @Timeout(1)
-    void reset() throws StreamPlayerException {
-
-        assertNull(player.getSourceDataLine());
-
-        player.open(audioFile);
-        assertNotNull(player.getSourceDataLine());
-
-//        player.play();
-//        assertNotNull(player.getSourceDataLine());
-
-        player.reset();
-        assertNull(player.getSourceDataLine());
-        player.stop();
-
-
-    }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -1,0 +1,98 @@
+package com.goxr3plus.streamplayer.stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.logging.Logger;
+
+import static java.lang.Math.log10;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class SourceDataLineTest {
+
+    StreamPlayer player;
+    private File audioFile;
+
+    @BeforeEach
+    void setup() {
+        final Logger logger = mock(Logger.class);
+        player = new StreamPlayer(logger);
+        audioFile = new File("Logic - Ballin [Bass Boosted].mp3");
+    }
+
+    @Test
+    void gain() throws StreamPlayerException, InterruptedException {
+        // Setup
+        final double gain1 = 0.83;
+        final double gain2 = 0.2;
+        final double delta = 0.05;
+        final boolean listen = false;
+
+        // Exercise
+        final float initialGain = player.getGainValue();
+        player.open(audioFile);
+        player.seekTo(30);
+        player.play();
+        player.setGain(gain1);
+        final float actualGain1First = player.getGainValue();
+        if (listen) Thread.sleep(2000);
+        final float actualGain1 = player.getGainValue();
+
+        player.setGain(gain2);
+        if (listen) Thread.sleep(2000);
+        final float actualGain2 = player.getGainValue();
+
+        player.setGain(gain1);
+        if (listen) Thread.sleep(2000);
+
+        player.stop();
+
+        // Verify
+        assertEquals(0, initialGain);
+        assertEquals(actualGain1First, actualGain1);
+        assertEquals(20*log10(gain1), actualGain1, delta);  // TODO: Investigate probable bug.
+        //  fail("Test not done");
+    }
+
+    /**
+     * Plays music if "listen" is true.
+     * Varies the gain, and checks that it can be read back.
+     * If listen is true, it plays for 2 seconds per gain level.
+     *
+     * @throws StreamPlayerException
+     * @throws InterruptedException
+     */
+    @Test
+    void logScaleGain() throws StreamPlayerException, InterruptedException {
+        // Setup
+        final boolean listen = false;
+
+        // Exercise
+
+        player.open(audioFile);
+        player.seekTo(30);
+        player.play();
+
+        assertGainCanBeSetTo(-10, listen);
+        assertGainCanBeSetTo(-75, listen);
+        assertGainCanBeSetTo(0, listen);
+        assertGainCanBeSetTo(6, listen);
+
+        player.stop();
+    }
+
+    private void assertGainCanBeSetTo(double gain, boolean listen) throws InterruptedException {
+        final float atGain = playAtGain(listen, gain);
+        assertEquals(gain, atGain, 0.01);
+    }
+
+    private float playAtGain(boolean listen, double gain) throws InterruptedException {
+        player.setLogScaleGain(gain);
+        if (listen) {
+            Thread.sleep(2000);
+        }
+        return player.getGainValue();
+    }
+}

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -95,4 +95,23 @@ public class SourceDataLineTest {
         }
         return player.getGainValue();
     }
+
+    @Test
+    void balance() throws StreamPlayerException {
+        // Setup
+        final float wantedBalance = 0.5f;
+
+        //Exercise
+        player.open(audioFile);
+        player.play();  // Necessary to be able to set the balance
+
+        final float initialBalance = player.getBalance();
+        player.setBalance(wantedBalance);
+        player.stop();  // Probably not needed, but cleanup is good.
+        final float actualBalance = player.getBalance();  // Can be made before or after stop()
+
+        // Verify
+        assertEquals(0, initialBalance);
+        assertEquals(wantedBalance, actualBalance);
+    }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/SourceDataLineTest.java
@@ -3,6 +3,7 @@ package com.goxr3plus.streamplayer.stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 
 import javax.sound.sampled.SourceDataLine;
 import java.io.File;
@@ -10,6 +11,7 @@ import java.util.logging.Logger;
 
 import static java.lang.Math.log10;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.booleanThat;
 import static org.mockito.Mockito.mock;
 
 public class SourceDataLineTest {
@@ -168,5 +170,23 @@ public class SourceDataLineTest {
         player.play();
 
         assertNotNull(player.getSourceDataLine());
+    }
+
+    @Test
+    void playAndPause() throws StreamPlayerException, InterruptedException {
+        boolean listen = true;
+        player.open(audioFile);
+        player.play();
+        player.seekTo(30);
+        if (listen) Thread.sleep(2000);
+
+        player.pause();
+        if (listen) Thread.sleep(1000);
+
+        player.resume();  // TODO: Examine what happens if play() is called instead.
+        if (listen) Thread.sleep(2000);
+        //player.stop();
+
+        // TODO: asserts and listen=false
     }
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -344,7 +344,7 @@ public class StreamPlayerMethodsTest {
     }
 
 
-    // The methods tested below aren't used otherwhere in this project, nor in XR3Player
+    // The methods tested below aren't used elsewhere in this project, nor in XR3Player
 
     @Test
     void lineBufferSize() {

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -197,13 +197,15 @@ public class StreamPlayerMethodsTest {
     }
 
     @Test
-    void sourceDataLine() {
-        final SourceDataLine sourceDataLine = player.getOutlet().getSourceDataLine();
+    void sourceDataLine() throws StreamPlayerException {
+        assertNull(player.getSourceDataLine());
 
+        player.open(audioFile);
+        assertNotNull(player.getSourceDataLine());
 
-        assertNotNull(sourceDataLine);
+        player.play();
 
-        fail("Test not done");
+        assertNotNull(player.getSourceDataLine());
     }
 
     @Test

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -295,11 +295,21 @@ public class StreamPlayerMethodsTest {
     }
 
     @Test
-    void pan() {
-        player.getPan();
-        player.setPan(1000);
+    void pan() throws StreamPlayerException {
+        double delta = 1e-6;
+        final float initialPan = player.getPan();
+        assertEquals(0, initialPan);
 
-        fail("Test not done");
+        player.open(audioFile);
+        player.play();
+
+        double pan = -0.9;
+        player.setPan(pan);
+        assertEquals(pan, player.getPan(), delta);
+
+        double outsideRange = 1.1;
+        player.setPan(outsideRange);
+        assertEquals(pan, player.getPan(), delta);
     }
 
     @Test

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -198,7 +198,8 @@ public class StreamPlayerMethodsTest {
 
     @Test
     void sourceDataLine() {
-        final SourceDataLine sourceDataLine = player.getSourceDataLine();
+        final SourceDataLine sourceDataLine = player.getOutlet().getSourceDataLine();
+
 
         assertNotNull(sourceDataLine);
 


### PR DESCRIPTION
This is just a draft. It should not be merged.

I'm playing with the idea of splitting StreamPlayer into smaller classes. As a first try, I have created a new class Outlet (maybe a bad name, but it can be changed). The SourceDataStream and the associated controls (gain, pan etc) have been moved to the new class.
A few methods have been moved to the new class. More will follow. The methods that I'm moving are the ones that primarily work on the fields that have already been moved.

I have also made an interface with the public methods of StreamPlayer. The intention is to have a safety net, so that I don't change the de-facto interface (as seen by the application) by mistake.
But the separation can be better, if the interface can be changed, so that the application cannot call streamPlayer.getGain(), but has to call outlet.getGain() for the same purpose. If that is allowed, the wrapper methods in StreamPlayer that now calls methods in Outlet can be removed.

Again: this is experimental. 
The application works as usual. Unit tests test were written before the refactoring, and work after it too.

See also: https://refactoring.com/catalog/extractClass.html 