### PR TITLE
Deprecate open(Object)

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -29,7 +29,10 @@ import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.Mixer;
 import javax.sound.sampled.SourceDataLine;
 import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -248,20 +251,62 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 * @param object the object [File or URL or InputStream ]
 	 *
 	 * @throws StreamPlayerException the stream player exception
+	 * @deprecated Use one of {@link #open(File)}, {@link #open(URL)} or {@link #open(InputStream)} instead.
+	 *
 	 */
 	@Override
+	@Deprecated
 	public void open(final Object object) throws StreamPlayerException {
 
 		logger.info(() -> "open(" + object + ")\n");
 		if (object == null)
 			return;
 
-		//source = new DataSource(object);
 		try {
 			source = DataSource.newDataSource(object);
 		} catch (OperationNotSupportedException e) {
 			e.printStackTrace();
 		}
+		initAudioInputStream();
+	}
+
+	/**
+	 * Open the specified file for playback.
+	 *
+	 * @param file the file to be played
+	 * @throws StreamPlayerException the stream player exception
+	 */
+	@Override
+	public void open(File file) throws StreamPlayerException {
+
+		logger.info(() -> "open(" + file + ")\n");
+		source = new FileDataSource(file);
+		initAudioInputStream();
+	}
+
+	/**
+	 * Open the specified location for playback.
+	 *
+	 * @param url the location to be played
+	 * @throws StreamPlayerException the stream player exception
+	 */
+	@Override
+	public void open(URL url) throws StreamPlayerException {
+		logger.info(() -> "open(" + url + ")\n");
+		source = new UrlDataSource(url);
+		initAudioInputStream();
+	}
+
+	/**
+	 * Open the specified stream for playback.
+	 *
+	 * @param stream the stream to be played
+	 * @throws StreamPlayerException the stream player exception
+	 */
+	@Override
+	public void open(InputStream stream) throws StreamPlayerException {
+		logger.info(() -> "open(" + stream + ")\n");
+		source = new StreamDataSource(stream);
 		initAudioInputStream();
 	}
 

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
@@ -3,8 +3,10 @@ package com.goxr3plus.streamplayer.stream;
 import com.goxr3plus.streamplayer.enums.Status;
 
 import javax.sound.sampled.SourceDataLine;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 public interface StreamPlayerInterface {
     /**
@@ -27,13 +29,42 @@ public interface StreamPlayerInterface {
     void removeStreamPlayerListener(StreamPlayerListener streamPlayerListener);
 
     /**
-     * Open the specific object which can be File,URL or InputStream.
+     * Open the specified object which can be File,URL or InputStream.
      *
      * @param object the object [File or URL or InputStream ]
      *
      * @throws StreamPlayerException the stream player exception
+     * @deprecated Use one of {@link #open(File)}, {@link #open(URL)} or {@link #open(InputStream)} instead.
      */
+    @Deprecated
     void open(Object object) throws StreamPlayerException;
+
+    /**
+     * Open the specified file for playback.
+     *
+     * @param file the file to be played
+     *
+     * @throws StreamPlayerException the stream player exception
+     */
+    void open(File file) throws StreamPlayerException;
+
+    /**
+     * Open the specified location for playback.
+     *
+     * @param url the location to be played
+     *
+     * @throws StreamPlayerException the stream player exception
+     */
+    void open(URL url) throws StreamPlayerException;
+
+    /**
+     * Open the specified stream for playback.
+     *
+     * @param stream the stream to be played
+     *
+     * @throws StreamPlayerException the stream player exception
+     */
+    void open(InputStream stream) throws StreamPlayerException;
 
     /**
      * Change the Speed Rate of the Audio , this variable affects the Sample Rate ,

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -324,7 +324,8 @@ public class StreamPlayerMethodsTest {
 
     @Test
     void open() throws StreamPlayerException {
-        player.open(null);
+        File file = null;
+        player.open(file);
 
         fail("Test not done");
     }


### PR DESCRIPTION
It's better to know at compile time that you cannot call open(String). If open(Objet) is permitted, the error appears at runtime, not compile time.