### PR TITLE
Solves "Synchronization on a non-final field 'audioLock'"

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -81,7 +81,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	/**
 	 * It is used for synchronization in place of audioInputStream
 	 */
-	private volatile Object audioLock = new Object();
+	private final Object audioLock = new Object();
 
 	// -------------------VARIABLES---------------------
 


### PR DESCRIPTION
as reported by IntelliJ: Analyze --> Inspect Code...

This shouldn't change any actual behavior, since there are no write operations on audioLock. So effectivly, it was already final and non-volatile. This change explicitly forbids write operations on audioLock.

Tested, of course.