### PR TITLE
AudioSystem.getMixerInfo() will not return null, so we don't have to …

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -35,11 +35,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -994,17 +990,16 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		// audio mixers that are currently installed on the system.
 		final Mixer.Info[] mixerInfos = AudioSystem.getMixerInfo();
 
-		if (mixerInfos != null)
-			Arrays.stream(mixerInfos).forEach(mInfo -> {
-				// line info
-				final Line.Info lineInfo = new Line.Info(SourceDataLine.class);
-				final Mixer mixer = AudioSystem.getMixer(mInfo);
+		Arrays.stream(mixerInfos).forEach(mInfo -> {
+			// line info
+			final Line.Info lineInfo = new Line.Info(SourceDataLine.class);
+			final Mixer mixer = AudioSystem.getMixer(mInfo);
 
-				// if line supported
-				if (mixer.isLineSupported(lineInfo))
-					mixers.add(mInfo.getName());
+			// if line supported
+			if (mixer.isLineSupported(lineInfo))
+				mixers.add(mInfo.getName());
 
-			});
+		});
 
 		return mixers;
 	}
@@ -1023,7 +1018,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		// audio mixers that are currently installed on the system.
 		final Mixer.Info[] mixerInfos = AudioSystem.getMixerInfo();
 
-		if (name != null && mixerInfos != null)
+		if (name != null)
             for (Mixer.Info mixerInfo : mixerInfos)
                 if (mixerInfo.getName().equals(name)) {
                     mixer = AudioSystem.getMixer(mixerInfo);


### PR DESCRIPTION
…check for it.

# Description

Null checks clutter the code, and should be removed when not needed. AudioSystem.getMixerInfo() will not return null, so we don't have to check if it returns null. AudioSystem.getMixerInfo() may return an empty array.

There are no dependencies for this change

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Code style update
- [ x] Refactor
- [ ] Build-related changes
- [ ] This change requires a documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

# Has This Been Tested?

- [x ] Yes
- [ ] No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
