### PR TITLE
Re-assignment of audioInputStream removed 

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -67,7 +67,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	private DataSource source;
 
 	/** The encoded audio input stream. mp3, ogg or similar */
-	private volatile AudioInputStream encodedAudioInputStream;
+	private AudioInputStream encodedAudioInputStream;
 
 	/** Copy of the encoded audio input stream. */
 	private AudioInputStream encodedAudioInputStreamCopy;


### PR DESCRIPTION
# Description

Related to #55 

Re-assignment of audioInputStream removed by changing
audioInputStream = AudioSystem.getAudioInputStream(targetFormat, audioInputStream);

to assignment of a new variable.
Variable name changes: Initial audioInputStream changed to encodedAudioInputStream
audioInputStream after the re-assignment now assigned to a field called decodedAudioInputStream.
Old encodedAudioInputStream renamed to encodedAudioInputStreamCopy.


encodedAudioInputStream doesn't change, so it doesn't have to be volatile.

According to Sonar, Non-primitive fields should not be "volatile"
For primitive fields volatile inhibits caching. This is only of interest of the field changes value, but this one doesn't. Since the field is an object reference, value change in this context means that it gets replaced with a different object, but it will not happen.

See also https://wiki.sei.cmu.edu/confluence/display/java/CON50-J.+Do+not+assume+that+declaring+a+reference+volatile+guarantees+safe+publication+of+the+members+of+the+referenced+object

There are no dependencies for this change.



**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] This change requires a documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

# Has This Been Tested?

- [x] Yes
- [ ] No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
