### PR TITLE
Don't allow a null to be passed as StreamPlayerListener

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -237,6 +238,10 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 	 */
 	@Override
 	public void addStreamPlayerListener(final StreamPlayerListener streamPlayerListener) {
+
+		Objects.requireNonNull(streamPlayerListener,
+				"null is not allowed as StreamPlayerListener value.");
+
 		listeners.add(streamPlayerListener);
 	}
 

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerFutureImprovementTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerFutureImprovementTest.java
@@ -38,11 +38,13 @@ public class StreamPlayerFutureImprovementTest {
      */
     @Test
     void addStreamPlayerListener_dontAcceptNull() {
-        // Currently, we can add a null to the list of stream player listeners.
-        // Should that really be allowed?
-        assertThrows(Exception.class, () -> player.addStreamPlayerListener(null));
+        // We can't allow nulls in the list of listeners, because they will cause NullPointerExceptions.
+        // One way to handle it is to require that an exception is thrown immediately when we
+        // try to add the null.
+        assertThrows(NullPointerException.class, () -> player.addStreamPlayerListener(null));
 
-        fail("Test not done");
+        // An alternative way would be to use some kind of null annotation, to disallow
+        // nulls being passed at compile time.
     }
 
 


### PR DESCRIPTION
# Description
Don't allow a null to be passed as StreamPlayerListener,
since it will result in a later NullPointerException.
This change throws a NullPointerException when the null
is added as StreamPlayerListener, rather than later.

A better (future?) approach would be to disallow nulls
at compile time, possibly using annotations.

Adds import java.util.Objects;

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] This change requires a documentation update
- [x] Other, please describe: Improved behaviour in a fault situation (when a null is added as listener)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

# Has This Been Tested?

- [ x] Yes
- [ ] No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
