### PR TITLE
Removed method StreamPlayer.getPositionByte()

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -1174,21 +1174,6 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 		return encodedAudioLength;
 	}
 
-	/**
-	 * @return BytePosition
-	 */
-	@Override
-	public int getPositionByte() {
-		final int positionByte = AudioSystem.NOT_SPECIFIED;
-		if (audioProperties != null) {
-			if (audioProperties.containsKey("mp3.position.byte"))
-				return (Integer) audioProperties.get("mp3.position.byte");
-			if (audioProperties.containsKey("ogg.position.byte"))
-				return (Integer) audioProperties.get("ogg.position.byte");
-		}
-		return positionByte;
-	}
-
 	/** The source data line. */
 	public Outlet getOutlet() {
 		return outlet;

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayerInterface.java
@@ -231,11 +231,6 @@ public interface StreamPlayerInterface {
     long getTotalBytes();
 
     /**
-     * @return BytePosition
-     */
-    int getPositionByte();
-
-    /**
      * Gets the source data line.
      *
      * @return The SourceDataLine

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerFutureImprovementTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerFutureImprovementTest.java
@@ -53,21 +53,4 @@ public class StreamPlayerFutureImprovementTest {
         assertThrows(Exception.class, () -> player.play());
     }
 
-    @Test
-    void seekBytes() throws StreamPlayerException {
-        player.open(audioFile);
-        player.play();
-        int positionByte1 = player.getPositionByte();
-
-        player.seekBytes(100);
-        int positionByte2 = player.getPositionByte();
-
-        assertTrue( positionByte2 > positionByte1);
-
-        // TODO: It seems that getPositionByte doesn't work.
-        //  It isn't called from within this project, except for in this test.
-        //  It is however called by XR3Player. If XR3Player needs this method, it must be tested
-        //  within this project. The method relies on a map, which doesn't seem to be updated by play()
-    }
-
 }

--- a/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
+++ b/src/test/java/com/goxr3plus/streamplayer/stream/StreamPlayerMethodsTest.java
@@ -541,13 +541,6 @@ public class StreamPlayerMethodsTest {
     }
 
     @Test
-    void positionByte() {
-        player.getPositionByte();
-
-        fail("Test not done");
-    }
-
-    @Test
     void precision() throws StreamPlayerException {
         assertEquals(0f, player.getPrecision());
 


### PR DESCRIPTION
# Description

The method was used in a unit test, as a means to
test the StreamPlayer.seekTo() method, but it never
worked. The StreamPlayer.getPositionByte() didn't seem
to work.

There are no other callers of getPositionByte() method in this codebase.
It is not used by XR3Player. It seems safe to remove it.

If the method really worked (which I doubt), then this is a
non-backwards-compatible change.

This change is a part of an effort to make all unit tests pass, by either updating the production code, the tests, or remove the failing tests.


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] This change requires a documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes, if the removed method actually works and is used.
- [ ] No

# Has This Been Tested?

- [X] Yes
- [ ] No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
