### PR TITLE
Remove cyclic dependency by moving creation method to factory class

### DIFF
--- a/src/main/java/com/goxr3plus/streamplayer/stream/DataSource.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/DataSource.java
@@ -1,28 +1,12 @@
 package com.goxr3plus.streamplayer.stream;
 
-import javax.naming.OperationNotSupportedException;
 import javax.sound.sampled.AudioFileFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.UnsupportedAudioFileException;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.time.Duration;
 
 public interface DataSource {
-    static DataSource newDataSource(Object source) throws OperationNotSupportedException {
-        if (source instanceof File) {
-            return new FileDataSource((File) source);
-        }
-        if (source instanceof URL) {
-            return new UrlDataSource((URL) source);
-        }
-        if (source instanceof InputStream) {
-            return new StreamDataSource((InputStream) source);
-        }
-        throw new OperationNotSupportedException();
-    }
 
     Object getSource(); // TODO: Try to make this method not needed.
 

--- a/src/main/java/com/goxr3plus/streamplayer/stream/DataSourceFactory.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/DataSourceFactory.java
@@ -1,0 +1,24 @@
+package com.goxr3plus.streamplayer.stream;
+
+import javax.naming.OperationNotSupportedException;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+
+public class DataSourceFactory {
+
+    private DataSourceFactory() {}
+
+    public static DataSource newDataSource(Object source) throws OperationNotSupportedException {
+        if (source instanceof File) {
+            return new FileDataSource((File) source);
+        }
+        if (source instanceof URL) {
+            return new UrlDataSource((URL) source);
+        }
+        if (source instanceof InputStream) {
+            return new StreamDataSource((InputStream) source);
+        }
+        throw new OperationNotSupportedException();
+    }
+}

--- a/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
+++ b/src/main/java/com/goxr3plus/streamplayer/stream/StreamPlayer.java
@@ -10,6 +10,14 @@
 
 package com.goxr3plus.streamplayer.stream;
 
+import com.goxr3plus.streamplayer.enums.Status;
+import com.goxr3plus.streamplayer.stream.StreamPlayerException.PlayerException;
+import javazoom.spi.PropertiesContainer;
+import org.tritonus.share.sampled.TAudioFormat;
+import org.tritonus.share.sampled.file.TAudioFileFormat;
+
+import javax.naming.OperationNotSupportedException;
+import javax.sound.sampled.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,41 +25,10 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.naming.OperationNotSupportedException;
-import javax.sound.sampled.AudioFileFormat;
-import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.BooleanControl;
-import javax.sound.sampled.DataLine;
-import javax.sound.sampled.FloatControl;
-import javax.sound.sampled.Line;
-import javax.sound.sampled.LineUnavailableException;
-import javax.sound.sampled.Mixer;
-import javax.sound.sampled.SourceDataLine;
-import javax.sound.sampled.UnsupportedAudioFileException;
-
-import org.tritonus.share.sampled.TAudioFormat;
-import org.tritonus.share.sampled.file.TAudioFileFormat;
-
-import com.goxr3plus.streamplayer.enums.Status;
-import com.goxr3plus.streamplayer.stream.StreamPlayerException.PlayerException;
-
-import javazoom.spi.PropertiesContainer;
 
 /**
  * StreamPlayer is a class based on JavaSound API. It has been successfully tested under Java 10
@@ -275,7 +252,7 @@ public class StreamPlayer implements StreamPlayerInterface, Callable<Void> {
 			return;
 
 		try {
-			source = DataSource.newDataSource(object);
+			source = DataSourceFactory.newDataSource(object);
 		} catch (OperationNotSupportedException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
# Description

A static creation method is moved from an interface to a new factory class,
in order to break a dependency cycle.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update
- [ x] Refactor
- [ ] Build-related changes
- [ ] This change requires a documentation update
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ x] No

# Has This Been Tested?

- [ x] Yes
- [ ] No

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
